### PR TITLE
Update explorer icons using vscode-icons

### DIFF
--- a/images/dark/icon-flat.svg
+++ b/images/dark/icon-flat.svg
@@ -1,37 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#2D2D30;}
-	.st1{fill:#C5C5C5;}
-</style>
-<g id="_x7B__PAGE_GRID__x7D_">
-</g>
-<g id="outline">
-	<path class="st0" d="M1,1h5v1h10v3H6v2h10v3H6v2h10v3H6v1H1V1z"/>
-</g>
-<g id="icon_x5F_bg">
-	<g>
-		<path class="st1" d="M2,2v3h3V2H2z M4,4H3V3h1V4z"/>
-	</g>
-	<g>
-		<path class="st1" d="M2,7v3h3V7H2z M4,9H3V8h1V9z"/>
-	</g>
-	<g>
-		<path class="st1" d="M2,12v3h3v-3H2z M4,14H3v-1h1V14z"/>
-	</g>
-	<rect x="6" y="3" class="st1" width="9" height="1"/>
-	<rect x="6" y="8" class="st1" width="9" height="1"/>
-	<rect x="6" y="13" class="st1" width="9" height="1"/>
-</g>
-<g id="icon_x5F_fg">
-	<path class="st0" d="M3,3v1h1V3H3z"/>
-	<path class="st0" d="M3,8v1h1V8H3z"/>
-	<path class="st0" d="M3,13v1h1v-1H3z"/>
-</g>
-<g id="not_x5F_bg">
-</g>
-<g id="not_x5F_fg">
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2V5H5V2H2ZM4 4H3V3H4V4Z" fill="#C5C5C5"/>
+<path d="M2 7V10H5V7H2ZM4 9H3V8H4V9Z" fill="#C5C5C5"/>
+<path d="M2 12V15H5V12H2ZM4 14H3V13H4V14Z" fill="#C5C5C5"/>
+<path d="M15 3H6V4H15V3Z" fill="#C5C5C5"/>
+<path d="M15 8H6V9H15V8Z" fill="#C5C5C5"/>
+<path d="M15 13H6V14H15V13Z" fill="#C5C5C5"/>
 </svg>

--- a/images/dark/icon-hierarchical.svg
+++ b/images/dark/icon-hierarchical.svg
@@ -1,23 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#2D2D30;}
-	.st1{fill:#C5C5C5;}
-</style>
-<g id="_x7B__PAGE_GRID__x7D_">
-</g>
-<g id="outline">
-	<path class="st0" d="M2,6H1V1h5v1h10v3H6v1h4v1h6v3h-6v2h6v3h-6v1H5v-1H2V6z"/>
-</g>
-<g id="icon_x5F_bg">
-	<path class="st1" d="M9,10V7H6v1H4V5h1V2H2v3h1v9h3v1h3v-3H6v1H4V9h2v1H9z M7,8h1v1H7V8z M3,3h1v1H3V3z M7,13h1v1H7V13z"/>
-	<rect x="6" y="3" class="st1" width="9" height="1"/>
-	<rect x="10" y="8" class="st1" width="5" height="1"/>
-	<rect x="10" y="13" class="st1" width="5" height="1"/>
-</g>
-<g id="icon_x5F_fg">
-	<path class="st0" d="M7,13v1h1v-1H7z M7,8v1h1V8H7z M3,3v1h1V3H3z"/>
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 10V7H6V8H4V5H5V2H2V5H3V14H6V15H9V12H6V13H4V9H6V10H9ZM7 8H8V9H7V8ZM3 3H4V4H3V3ZM7 13H8V14H7V13Z" fill="#C5C5C5"/>
+<path d="M15 3H6V4H15V3Z" fill="#C5C5C5"/>
+<path d="M15 8H10V9H15V8Z" fill="#C5C5C5"/>
+<path d="M15 13H10V14H15V13Z" fill="#C5C5C5"/>
 </svg>

--- a/images/dark/icon-link.svg
+++ b/images/dark/icon-link.svg
@@ -1,18 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#252526;}
-	.st1{fill:#C5C5C5;}
-</style>
-<g id="canvas">
-	<rect class="st0" width="16" height="16"/>
-</g>
-<g id="outline">
-	<polygon class="st0" points="11.4,7 13,7 13,3 7.4,3 9.4,1 4.6,1 0.6,5 4.6,9 3,9 3,13 8.6,13 6.6,15 11.4,15 15.4,11 	"/>
-</g>
-<g id="iconBg">
-	<path class="st1" d="M14,11l-3,3H9l2-2H4v-2h7L9,8h2L14,11z M7,8L5,6h7V4H5l2-2H5L2,5l3,3H7z"/>
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 10.5L10.8536 7.85353L11.5607 7.14642L14.5607 10.1464V10.8535L11.5607 13.8535L10.8536 13.1464L13.5 10.5Z" fill="#C5C5C5"/>
+<path d="M2 10H14V11H2V10Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.50001 5.49996L5.14645 8.14641L4.43935 8.85352L1.43935 5.85352L1.43935 5.14641L4.43935 2.14641L5.14645 2.85352L2.50001 5.49996Z" fill="#C5C5C5"/>
+<path d="M2 5H14V6H2V5Z" fill="#C5C5C5"/>
 </svg>

--- a/images/dark/icon-refresh.svg
+++ b/images/dark/icon-refresh.svg
@@ -1,14 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="图层_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#2D2D30;}
-	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#C5C5C5;}
-</style>
-<path class="st0" d="M7,0.7v1.4C3.6,2.6,1,5.5,1,9c0,3.7,2.9,6.7,6.5,7h1c3.6-0.2,6.5-3.3,6.5-7c0-0.5-0.1-1.1-0.2-1.6l-0.3-1.1
-	l-1.1,0.4l-1.9,0.8l-0.8,0.3L11,8.6c0,0.2,0,0.3,0,0.5c0,1.7-1.3,3-3,3c-1.7,0-3-1.3-3-3c0-1.3,0.8-2.4,2-2.8v1.1v2.1l1.6-1.4l4-3.3
-	L13.6,4l-0.9-0.8L8.7,0H7V0.7z"/>
-<path class="st1" d="M12,4L8,7.3V5C5.8,5,4,6.8,4,9c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4c0-0.2,0-0.4-0.1-0.6l1.9-0.8
-	C13.9,8.1,14,8.5,14,9c0,3.3-2.7,6-6,6c-3.3,0-6-2.7-6-6c0-3.3,2.7-6,6-6V0.7L12,4z"/>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5.56253 2.5158C3.46348 3.45013 2 5.55417 2 8.00002C2 11.3137 4.68629 14 8 14C11.3137 14 14 11.3137 14 8.00002C14 5.32522 12.2497 3.05922 9.83199 2.28485L9.52968 3.23835C11.5429 3.88457 13 5.77213 13 8.00002C13 10.7614 10.7614 13 8 13C5.23858 13 3 10.7614 3 8.00002C3 6.31107 3.83742 4.8177 5.11969 3.91248L5.56253 2.5158Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5 3H2V2H5.5L6 2.5V6H5V3Z" fill="#C5C5C5"/>
 </svg>

--- a/images/dark/icon-unlink.svg
+++ b/images/dark/icon-unlink.svg
@@ -1,15 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#252526;}
-	.st1{fill:#C5C5C5;}
-</style>
-<g id="outline">
-	<polyline class="st0" points="13,3 7.4,3 9.4,1 4.6,1 0.6,5 4.6,9 3,9 3,13 8.6,13 6.6,15 11.4,15 15.4,11 11.4,7 13,7 	"/>
-</g>
-<g id="iconBg">
-	<path class="st1" d="M14,11l-3,3H9l2-2H4v-2h7L9,8h2L14,11z M7,8L5,6h7V4H5l2-2H5L2,5l3,3H7z"/>
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 10.5L10.8536 7.85353L11.5607 7.14642L14.5607 10.1464V10.8535L11.5607 13.8535L10.8536 13.1464L13.5 10.5Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.50001 5.49996L5.14645 8.14641L4.43935 8.85352L1.43935 5.85352L1.43935 5.14641L4.43935 2.14641L5.14645 2.85352L2.50001 5.49996Z" fill="#C5C5C5"/>
+<path d="M14 6V5H11.1513L10.645 6H14Z" fill="#C5C5C5"/>
+<path d="M2 5V6H7.29009L7.78516 5H2Z" fill="#C5C5C5"/>
+<path d="M14 11V10H8.64453L8.14453 11H14Z" fill="#C5C5C5"/>
+<path d="M2 10V11H4.78906L5.28906 10H2Z" fill="#C5C5C5"/>
+<path d="M4.90799 13L5.80199 13.448L10.802 3.448L9.90799 3L4.90799 13Z" fill="#C5C5C5"/>
 </svg>

--- a/images/light/icon-flat.svg
+++ b/images/light/icon-flat.svg
@@ -1,38 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#F6F6F6;}
-	.st1{fill:#424242;}
-	.st2{fill:#F0EFF1;}
-</style>
-<g id="_x7B__PAGE_GRID__x7D_">
-</g>
-<g id="outline">
-	<path class="st0" d="M1,1h5v1h10v3H6v2h10v3H6v2h10v3H6v1H1V1z"/>
-</g>
-<g id="icon_x5F_bg">
-	<g>
-		<path class="st1" d="M2,2v3h3V2H2z M4,4H3V3h1V4z"/>
-	</g>
-	<g>
-		<path class="st1" d="M2,7v3h3V7H2z M4,9H3V8h1V9z"/>
-	</g>
-	<g>
-		<path class="st1" d="M2,12v3h3v-3H2z M4,14H3v-1h1V14z"/>
-	</g>
-	<rect x="6" y="3" class="st1" width="9" height="1"/>
-	<rect x="6" y="8" class="st1" width="9" height="1"/>
-	<rect x="6" y="13" class="st1" width="9" height="1"/>
-</g>
-<g id="icon_x5F_fg">
-	<path class="st2" d="M3,3v1h1V3H3z"/>
-	<path class="st2" d="M3,8v1h1V8H3z"/>
-	<path class="st2" d="M3,13v1h1v-1H3z"/>
-</g>
-<g id="not_x5F_bg">
-</g>
-<g id="not_x5F_fg">
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2V5H5V2H2ZM4 4H3V3H4V4Z" fill="#424242"/>
+<path d="M2 7V10H5V7H2ZM4 9H3V8H4V9Z" fill="#424242"/>
+<path d="M2 12V15H5V12H2ZM4 14H3V13H4V14Z" fill="#424242"/>
+<path d="M15 3H6V4H15V3Z" fill="#424242"/>
+<path d="M15 8H6V9H15V8Z" fill="#424242"/>
+<path d="M15 13H6V14H15V13Z" fill="#424242"/>
 </svg>

--- a/images/light/icon-hierarchical.svg
+++ b/images/light/icon-hierarchical.svg
@@ -1,28 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#F6F6F6;}
-	.st1{fill:#424242;}
-	.st2{fill:#F0EFF1;}
-</style>
-<g id="_x7B__PAGE_GRID__x7D_">
-</g>
-<g id="outline">
-	<path class="st0" d="M2,6H1V1h5v1h10v3H6v1h4v1h6v3h-6v2h6v3h-6v1H5v-1H2V6z"/>
-</g>
-<g id="icon_x5F_bg">
-	<path class="st1" d="M9,10V7H6v1H4V5h1V2H2v3h1v9h3v1h3v-3H6v1H4V9h2v1H9z M7,8h1v1H7V8z M3,3h1v1H3V3z M7,13h1v1H7V13z"/>
-	<rect x="6" y="3" class="st1" width="9" height="1"/>
-	<rect x="10" y="8" class="st1" width="5" height="1"/>
-	<rect x="10" y="13" class="st1" width="5" height="1"/>
-</g>
-<g id="icon_x5F_fg">
-	<path class="st2" d="M7,13v1h1v-1H7z M7,8v1h1V8H7z M3,3v1h1V3H3z"/>
-</g>
-<g id="not_x5F_bg">
-</g>
-<g id="not_x5F_fg">
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 10V7H6V8H4V5H5V2H2V5H3V14H6V15H9V12H6V13H4V9H6V10H9ZM7 8H8V9H7V8ZM3 3H4V4H3V3ZM7 13H8V14H7V13Z" fill="#424242"/>
+<path d="M15 3H6V4H15V3Z" fill="#424242"/>
+<path d="M15 8H10V9H15V8Z" fill="#424242"/>
+<path d="M15 13H10V14H15V13Z" fill="#424242"/>
 </svg>

--- a/images/light/icon-link.svg
+++ b/images/light/icon-link.svg
@@ -1,18 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#F6F6F6;}
-	.st1{fill:#424242;}
-</style>
-<rect id="canvas" class="st0" width="16" height="16"/>
-<g id="outline">
-	<polygon class="st0" points="11.4,7 13,7 13,3 7.4,3 9.4,1 4.6,1 0.6,5 4.6,9 3,9 3,13 8.6,13 6.6,15 11.4,15 15.4,11 	"/>
-</g>
-<g id="iconBg">
-	<g>
-		<path class="st1" d="M14,11l-3,3H9l2-2H4v-2h7L9,8h2L14,11z M7,8L5,6h7V4H5l2-2H5L2,5l3,3H7z"/>
-	</g>
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 10.5L10.8536 7.85353L11.5607 7.14642L14.5607 10.1464V10.8535L11.5607 13.8535L10.8536 13.1464L13.5 10.5Z" fill="#424242"/>
+<path d="M2 10H14V11H2V10Z" fill="#424242"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.50001 5.49996L5.14645 8.14641L4.43935 8.85352L1.43935 5.85352L1.43935 5.14641L4.43935 2.14641L5.14645 2.85352L2.50001 5.49996Z" fill="#424242"/>
+<path d="M2 5H14V6H2V5Z" fill="#424242"/>
 </svg>

--- a/images/light/icon-refresh.svg
+++ b/images/light/icon-refresh.svg
@@ -1,14 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="图层_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#F6F6F6;}
-	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#424242;}
-</style>
-<path class="st0" d="M7,0.7v1.4C3.6,2.6,1,5.5,1,9c0,3.7,2.9,6.7,6.5,7h1c3.6-0.2,6.5-3.3,6.5-7c0-0.5-0.1-1.1-0.2-1.6l-0.3-1.1
-	l-1.1,0.4l-1.9,0.8l-0.8,0.3L11,8.6c0,0.2,0,0.3,0,0.5c0,1.7-1.3,3-3,3c-1.7,0-3-1.3-3-3c0-1.3,0.8-2.4,2-2.8v1.1v2.1l1.6-1.4l4-3.3
-	L13.6,4l-0.9-0.8L8.7,0H7V0.7z"/>
-<path class="st1" d="M12,4L8,7.3V5C5.8,5,4,6.8,4,9c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4c0-0.2,0-0.4-0.1-0.6l1.9-0.8
-	C13.9,8.1,14,8.5,14,9c0,3.3-2.7,6-6,6c-3.3,0-6-2.7-6-6c0-3.3,2.7-6,6-6V0.7L12,4z"/>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5.56253 2.5158C3.46348 3.45013 2 5.55417 2 8.00002C2 11.3137 4.68629 14 8 14C11.3137 14 14 11.3137 14 8.00002C14 5.32522 12.2497 3.05922 9.83199 2.28485L9.52968 3.23835C11.5429 3.88457 13 5.77213 13 8.00002C13 10.7614 10.7614 13 8 13C5.23858 13 3 10.7614 3 8.00002C3 6.31107 3.83742 4.8177 5.11969 3.91248L5.56253 2.5158Z" fill="#424242"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5 3H2V2H5.5L6 2.5V6H5V3Z" fill="#424242"/>
 </svg>

--- a/images/light/icon-unlink.svg
+++ b/images/light/icon-unlink.svg
@@ -1,17 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#F6F6F6;}
-	.st1{fill:#424242;}
-</style>
-<g id="outline">
-	<polygon class="st0" points="11.4,7 13,7 13,3 7.4,3 9.4,1 4.6,1 0.6,5 4.6,9 3,9 3,13 8.6,13 6.6,15 11.4,15 15.4,11 	"/>
-</g>
-<g id="iconBg">
-	<g>
-		<path class="st1" d="M14,11l-3,3H9l2-2H4v-2h7L9,8h2L14,11z M7,8L5,6h7V4H5l2-2H5L2,5l3,3H7z"/>
-	</g>
-</g>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 10.5L10.8535 7.85353L11.5606 7.14642L14.5606 10.1464V10.8535L11.5606 13.8535L10.8535 13.1464L13.5 10.5Z" fill="#424242"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.50004 5.49996L5.14648 8.14641L4.43938 8.85352L1.43938 5.85352L1.43938 5.14641L4.43938 2.14641L5.14648 2.85352L2.50004 5.49996Z" fill="#424242"/>
+<path d="M14 6V5H11.1513L10.645 6H14Z" fill="#424242"/>
+<path d="M2 5V6H7.29009L7.78516 5H2Z" fill="#424242"/>
+<path d="M14 11V10H8.64453L8.14453 11H14Z" fill="#424242"/>
+<path d="M2 10V11H4.78906L5.28906 10H2Z" fill="#424242"/>
+<path d="M4.90802 13L5.80202 13.448L10.802 3.448L9.90802 3L4.90802 13Z" fill="#424242"/>
 </svg>


### PR DESCRIPTION
Resolve: https://github.com/microsoft/vscode-java-dependency/issues/197

![demo](https://user-images.githubusercontent.com/6193897/68354906-a4a87d00-0148-11ea-9f2f-35987631d5dd.gif)

One problem is that in the light theme, the color defined in the [VSCode-Icons] repo is not aligned within the VS Code. So it would be really helpful if VS Code can expose the API to let the extension reuse its icons. See: https://github.com/microsoft/vscode/issues/31466