### PR TITLE
Refactor onDidChangeConfiguration handler in favor of listener pattern

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,10 +17,9 @@ export class Settings {
                 return;
             }
             const oldConfig = this._dependencyConfig;
-            const updatedConfig = workspace.getConfiguration("java.dependency");
-            this._dependencyConfig = updatedConfig;
+            this._dependencyConfig = workspace.getConfiguration("java.dependency");
             for (const listener of this._configurationListeners) {
-                listener(updatedConfig, oldConfig);
+                listener(this._dependencyConfig, oldConfig);
             }
         }));
         this.registerConfigurationListener((updatedConfig, oldConfig) => {

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -32,8 +32,8 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
             instrumentOperation(Commands.VIEW_PACKAGE_OPEN_FILE, (_operationId, uri) => this.openFile(uri))));
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_OUTLINE,
             instrumentOperation(Commands.VIEW_PACKAGE_OUTLINE, (_operationId, uri, range) => this.goToOutline(uri, range))));
-        Settings.registerConfigurationListener((updatedConfig, dependencyConfig) => {
-            if (updatedConfig.refreshDelay !== dependencyConfig.refreshDelay) {
+        Settings.registerConfigurationListener((updatedConfig, oldConfig) => {
+            if (updatedConfig.refreshDelay !== oldConfig.refreshDelay) {
                 this.setRefreshDelay(updatedConfig.refreshDelay);
             }
         });


### PR DESCRIPTION
This PR
* Refactor the `onDidChangeConfiguration` hanlder in favor of`listener(updatedConfig, oldConfig)` pattern.
* move the old logic into separate listeners
* makes sure that when a listener gets called, it will receive the **latest** configuration from `Settings.getSomeSetting`.