### PR TITLE
Support managing referenced libraries

### DIFF
--- a/images/dark/icon-add.svg
+++ b/images/dark/icon-add.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 7V8H8V14H7V8H1V7H7V1H8V7H14Z" fill="#C5C5C5"/>
+</svg>

--- a/images/dark/icon-remove.svg
+++ b/images/dark/icon-remove.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 8H1V7H15V8Z" fill="#C5C5C5"/>
+</svg>

--- a/images/light/icon-add.svg
+++ b/images/light/icon-add.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 7V8H8V14H7V8H1V7H7V1H8V7H14Z" fill="#424242"/>
+</svg>

--- a/images/light/icon-remove.svg
+++ b/images/light/icon-remove.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 8H1V7H15V8Z" fill="#424242"/>
+</svg>

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/plugin.xml
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/plugin.xml
@@ -3,6 +3,7 @@
 <plugin>
 <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
         <delegateCommandHandler class="com.microsoft.jdtls.ext.core.CommandHandler">
+            <command id="java.project.refreshLib"/>
             <command id="java.project.list"/>
             <command id="java.getPackageData"/>
             <command id="java.resolvePath" />

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/CommandHandler.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/CommandHandler.java
@@ -24,7 +24,9 @@ public class CommandHandler implements IDelegateCommandHandler {
         if (!StringUtils.isBlank(commandId)) {
             switch (commandId) {
                 case "java.project.list":
-                    return ProjectCommand.execute(arguments, monitor);
+                    return ProjectCommand.listProjects(arguments, monitor);
+                case "java.project.refreshLib":
+                    return ProjectCommand.refreshLibraries(arguments, monitor);
                 case "java.getPackageData":
                     return PackageCommand.getChildren(arguments, monitor);
                 case "java.resolvePath":

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
@@ -51,6 +51,7 @@ import org.eclipse.jdt.internal.core.JarEntryFile;
 import org.eclipse.jdt.internal.core.JarEntryResource;
 import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.CollectionTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EnumTypeAdapter;
 
@@ -246,7 +247,7 @@ public class PackageCommand {
                         .collect(Collectors.toList());
                 boolean isReferencedLibrariesExist = Arrays.stream(references)
                         .anyMatch(entry -> entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY || entry.getEntryKind() == IClasspathEntry.CPE_VARIABLE);
-                if (isReferencedLibrariesExist) {
+                if (isReferencedLibrariesExist || !ProjectUtils.isVisibleProject(javaProject.getProject())) {
                     result.add(PackageNode.REFERENCED_LIBRARIES_CONTAINER);
                 }
                 return result;

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -21,14 +21,19 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.managers.UpdateClasspathJob;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.ReferencedLibraries;
 
 import com.microsoft.jdtls.ext.core.model.NodeKind;
 import com.microsoft.jdtls.ext.core.model.PackageNode;
 
 public final class ProjectCommand {
 
-    public static List<PackageNode> execute(List<Object> arguments, IProgressMonitor monitor) {
+    public static List<PackageNode> listProjects(List<Object> arguments, IProgressMonitor monitor) {
         String workspaceUri = (String) arguments.get(0);
         IPath workspacePath = ResourceUtils.canonicalFilePathFromURI(workspaceUri);
         String invisibleProjectName = getWorkspaceInvisibleProjectName(workspacePath);
@@ -45,6 +50,21 @@ public final class ProjectCommand {
         }
 
         return children;
+    }
+
+    public static boolean refreshLibraries(List<Object> arguments, IProgressMonitor monitor) {
+        String workspaceUri = (String) arguments.get(0);
+        IPath workspacePath = ResourceUtils.canonicalFilePathFromURI(workspaceUri);
+        String projectName = ProjectUtils.getWorkspaceInvisibleProjectName(workspacePath);
+        IProject project = getWorkspaceRoot().getProject(projectName);
+        try {
+            ReferencedLibraries libraries = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getReferencedLibraries();
+            UpdateClasspathJob.getInstance().updateClasspath(JavaCore.create(project), libraries);
+            return true;
+        } catch (Exception e) {
+            JavaLanguageServerPlugin.logException("Exception occured during waiting for classpath to be updated", e);
+            return false;
+        }
     }
 
     private static IWorkspaceRoot getWorkspaceRoot() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -976,8 +976,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1065,9 +1064,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "bn.js": {
@@ -1080,7 +1079,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1242,27 +1240,34 @@
       "dev": true
     },
     "cacache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-      "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "figgy-pudding": "^3.1.0",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.3",
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^6.0.0",
-        "unique-filename": "^1.1.0",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        },
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -1433,9 +1438,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -1638,8 +1643,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1844,14 +1848,14 @@
       }
     },
     "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -2507,13 +2511,13 @@
       }
     },
     "find-cache-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-      "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
+        "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
     },
@@ -4797,9 +4801,9 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -4855,6 +4859,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true
     },
     "inflight": {
@@ -5064,6 +5074,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
@@ -5324,28 +5340,34 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -5908,7 +5930,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5972,7 +5993,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -6166,7 +6187,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -6525,12 +6546,12 @@
       "dev": true
     },
     "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
+        "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
       }
@@ -6603,7 +6624,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6668,7 +6689,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -6746,7 +6767,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -6772,12 +6793,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "public-encrypt": {
@@ -7470,12 +7485,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -7505,7 +7520,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -7543,9 +7558,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-      "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "set-blocking": {
@@ -7765,9 +7780,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -7948,7 +7963,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -7957,7 +7972,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -7996,38 +8011,39 @@
       "dev": true
     },
     "terser": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.11.0.tgz",
-      "integrity": "sha512-5iLMdhEPIq3zFWskpmbzmKwMQixKmTYwY3Ox9pjtSklBLnHiuQ0GKJLhL1HSYtyffHM3/lDIFBnb82m9D7ewwQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.1.tgz",
+      "integrity": "sha512-w0f2OWFD7ka3zwetgVAhNMeyzEbj39ht2Tb0qKflw9PmW9Qbo5tjTh01QJLkhO9t9RDDQYvk+WXqpECI2C6i2A==",
       "dev": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.6"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
-      "integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
-        "cacache": "^11.0.2",
-        "find-cache-dir": "^2.0.0",
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
-        "terser": "^3.8.1",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -8040,12 +8056,22 @@
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
           }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
         }
       }
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -8624,9 +8650,9 @@
       }
     },
     "unique-slug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -9643,9 +9669,9 @@
       "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
     },
     "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
@@ -9678,7 +9704,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
@@ -9694,9 +9720,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -230,17 +230,17 @@
         },
         {
           "command": "java.project.addLibraries",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container/referenced-libraries/",
           "group": "inline@0"
         },
         {
           "command": "java.project.removeLibrary",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:jar\/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:jar/referenced-libraries/",
           "group": "inline"
         },
         {
           "command": "java.project.refreshLibraries",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container/referenced-libraries/",
           "group": "inline@1"
         }
       ]
@@ -269,6 +269,7 @@
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.139",
+    "@types/minimatch": "^3.0.3",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.36",
     "@types/vscode": "1.30.0",
@@ -291,6 +292,7 @@
     "find-java-home": "^0.2.0",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.15",
+    "minimatch": "^3.0.4",
     "vscode-extension-telemetry-wrapper": "^0.4.0",
     "xml2js": "^0.4.19"
   }

--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
         {
           "command": "java.project.addLibraries",
           "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
-          "group": "inline@1"
+          "group": "inline@0"
         },
         {
           "command": "java.project.removeLibrary",
@@ -241,7 +241,7 @@
         {
           "command": "java.project.refreshLibraries",
           "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
-          "group": "inline@0"
+          "group": "inline@1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -230,17 +230,17 @@
         },
         {
           "command": "java.project.addLibraries",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:container/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
           "group": "inline@0"
         },
         {
           "command": "java.project.removeLibrary",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:jar/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:jar\/referenced-libraries/",
           "group": "inline"
         },
         {
           "command": "java.project.refreshLibraries",
-          "when": "view == javaDependencyExplorer && viewItem =~ /java:container/referenced-libraries/",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
           "group": "inline@1"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -279,7 +279,6 @@
     "gulp-copy": "^4.0.1",
     "gulp-tslint": "^8.1.3",
     "mocha": "^5.2.0",
-    "native-ext-loader": "^2.3.0",
     "shelljs": "^0.8.3",
     "ts-loader": "^5.3.1",
     "tslint": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,33 @@
         "category": "Java"
       },
       {
+        "command": "java.project.addLibraries",
+        "title": "%contributes.commands.java.project.addLibraries%",
+        "category": "Java",
+        "icon": {
+          "dark": "images/dark/icon-add.svg",
+          "light": "images/light/icon-add.svg"
+        }
+      },
+      {
+        "command": "java.project.removeLibrary",
+        "title": "%contributes.commands.java.project.removeLibrary%",
+        "category": "Java",
+        "icon": {
+          "dark": "images/dark/icon-remove.svg",
+          "light": "images/light/icon-remove.svg"
+        }
+      },
+      {
+        "command": "java.project.refreshLibraries",
+        "title": "%contributes.commands.java.view.package.refresh%",
+        "category": "Java",
+        "icon": {
+          "dark": "images/dark/icon-refresh.svg",
+          "light": "images/light/icon-refresh.svg"
+        }
+      },
+      {
         "command": "java.view.package.refresh",
         "title": "%contributes.commands.java.view.package.refresh%",
         "category": "Java",
@@ -148,6 +175,14 @@
         {
           "command": "java.view.package.copyRelativeFilePath",
           "when": "never"
+        },
+        {
+          "command": "java.project.removeLibrary",
+          "when": "never"
+        },
+        {
+          "command": "java.project.refreshLibraries",
+          "when": "never"
         }
       ],
       "view/title": [
@@ -192,6 +227,21 @@
           "command": "java.view.package.copyRelativeFilePath",
           "when": "view == javaDependencyExplorer && viewItem =~ /java:.*?\\+uri/",
           "group": "@2"
+        },
+        {
+          "command": "java.project.addLibraries",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
+          "group": "inline@1"
+        },
+        {
+          "command": "java.project.removeLibrary",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:jar\/referenced-libraries/",
+          "group": "inline"
+        },
+        {
+          "command": "java.project.refreshLibraries",
+          "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries/",
+          "group": "inline@0"
         }
       ]
     },
@@ -229,6 +279,7 @@
     "gulp-copy": "^4.0.1",
     "gulp-tslint": "^8.1.3",
     "mocha": "^5.2.0",
+    "native-ext-loader": "^2.3.0",
     "shelljs": "^0.8.3",
     "ts-loader": "^5.3.1",
     "tslint": "^5.11.0",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,8 @@
 {
   "description": "Manage Java Dependencies in VSCode",
   "contributes.commands.java.project.create": "Create Java Project",
+  "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project library reference",
+  "contributes.commands.java.project.removeLibrary": "Remove jar file from project library reference",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.view.package.changeRepresentation": "Change package representation",
   "contributes.commands.java.view.package.changeToFlatPackageView":"Change to flat package representation",
@@ -14,6 +16,6 @@
   "configuration.java.dependency.showOutline": "Enable show outline in the Java Dependency explorer",
   "configuration.java.dependency.syncWithFolderExplorer": "Synchronize dependency viewer selection with folder explorer",
   "configuration.java.dependency.autoRefresh": "Synchronize dependency viewer with changes",
-  "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected.",
+  "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected",
   "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,8 +1,8 @@
 {
   "description": "Manage Java Dependencies in VSCode",
   "contributes.commands.java.project.create": "Create Java Project",
-  "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project library reference",
-  "contributes.commands.java.project.removeLibrary": "Remove jar file from project library reference",
+  "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project classpath",
+  "contributes.commands.java.project.removeLibrary": "Remove jar file from project classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.view.package.changeRepresentation": "Change package representation",
   "contributes.commands.java.view.package.changeToFlatPackageView":"Change to flat package representation",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,8 +1,8 @@
 {
   "description": "在 VSCode 中管理 Java 依赖项",
   "contributes.commands.java.project.create": "创建 Java 项目",
-  "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目引用库",
-  "contributes.commands.java.project.removeLibrary": "将 Jar 文件从 Java 项目引用库移除",
+  "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目类路径中",
+  "contributes.commands.java.project.removeLibrary": "将该 Jar 文件从 Java 项目类路径中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.view.package.changeRepresentation": "更改包展示形式",
   "contributes.commands.java.view.package.changeToFlatPackageView":"将 Java 包显示方式切换为平行显示",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,6 +1,8 @@
 {
   "description": "在 VSCode 中管理 Java 依赖项",
   "contributes.commands.java.project.create": "创建 Java 项目",
+  "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目引用库",
+  "contributes.commands.java.project.removeLibrary": "将 Jar 文件从 Java 项目引用库移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.view.package.changeRepresentation": "更改包展示形式",
   "contributes.commands.java.view.package.changeToFlatPackageView":"将 Java 包显示方式切换为平行显示",
@@ -14,6 +16,6 @@
   "configuration.java.dependency.showOutline": "在 Java 依赖项资源管理器中显示类成员大纲",
   "configuration.java.dependency.syncWithFolderExplorer": "在 Java 依赖项资源管理器中同步关联当前打开的文件",
   "configuration.java.dependency.autoRefresh": "在 Java 依赖项资源管理器中自动同步修改",
-  "configuration.java.dependency.refreshDelay": "控制Java 依赖项资源管理器刷新的延迟时间 (毫秒)。",
+  "configuration.java.dependency.refreshDelay": "控制Java 依赖项资源管理器刷新的延迟时间 (毫秒)",
   "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示"
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,7 +32,15 @@ export namespace Commands {
 
     export const JAVA_PROJECT_CREATE = "java.project.create";
 
+    export const JAVA_PROJECT_ADD_LIBRARIES = "java.project.addLibraries";
+
+    export const JAVA_PROJECT_REMOVE_LIBRARY = "java.project.removeLibrary";
+
+    export const JAVA_PROJECT_REFRESH_LIBRARIES = "java.project.refreshLibraries";
+
     export const JAVA_PROJECT_LIST = "java.project.list";
+
+    export const JAVA_PROJECT_REFRESH_LIB_SERVER = "java.project.refreshLib";
 
     export const JAVA_GETPACKAGEDATA = "java.getPackageData";
 

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as chokidar from "chokidar";
+import * as fse from "fs-extra";
+import * as _ from "lodash";
+import { commands, Disposable, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from "vscode";
+import { instrumentOperation } from "vscode-extension-telemetry-wrapper";
+import { Commands } from "../commands";
+import { Jdtls } from "../java/jdtls";
+import { Settings } from "../settings";
+import { Utility } from "../utility";
+import { DataNode } from "../views/dataNode";
+
+export class LibraryController implements Disposable {
+
+    private libraryWatcher: chokidar.FSWatcher | undefined = undefined;
+
+    public constructor(public readonly context: ExtensionContext) {
+        context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_ADD_LIBRARIES,
+            instrumentOperation(Commands.JAVA_PROJECT_ADD_LIBRARIES, (operationId: string, node: DataNode) => this.addLibraries())));
+        context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_REMOVE_LIBRARY,
+            instrumentOperation(Commands.JAVA_PROJECT_REMOVE_LIBRARY, (operationId: string, node: DataNode) => this.removeLibrary(node.path))));
+        context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_REFRESH_LIBRARIES,
+            instrumentOperation(Commands.JAVA_PROJECT_REFRESH_LIBRARIES, (operationId: string, node: DataNode) => this.refreshLibraries())));
+    }
+
+    public dispose() {
+        if (this.libraryWatcher) {
+            this.libraryWatcher.close();
+            this.libraryWatcher = undefined;
+        }
+    }
+
+    public async addLibraries(libraryGlobs?: string[]) {
+        if (!libraryGlobs) {
+            libraryGlobs = [];
+            const workspaceFolder: WorkspaceFolder | undefined = Utility.getDefaultWorkspaceFolder();
+            const results: Uri[] | undefined = await window.showOpenDialog({
+                defaultUri: workspaceFolder && workspaceFolder.uri,
+                canSelectFiles: true,
+                canSelectFolders: true,
+                canSelectMany: true,
+                openLabel: "Select",
+            });
+            if (!results) {
+                return;
+            }
+            libraryGlobs = await Promise.all(results.map(async (uri: Uri) => {
+                const uriPath = workspace.asRelativePath(uri, false);
+                return (await fse.stat(uri.fsPath)).isDirectory() ? `${uriPath}/**/*.jar` : uriPath;
+            }));
+        }
+        const setting = Settings.referencedLibraries();
+        if (Settings.isDefaultReferencedLibraries()) {
+            setting.include = [];
+        }
+        setting.include.push(...libraryGlobs);
+        Settings.updateReferencedLibraries(setting);
+    }
+
+    public async removeLibrary(library: string) {
+        const setting = Settings.referencedLibraries();
+        setting.exclude.push(workspace.asRelativePath(library));
+        Settings.updateReferencedLibraries(setting);
+    }
+
+    public async refreshLibraries(): Promise<void> {
+        const workspaceFolder = Utility.getDefaultWorkspaceFolder();
+        if (workspaceFolder) {
+            await Jdtls.refreshLibraries(workspaceFolder.uri.toString());
+        }
+    }
+}

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -39,7 +39,7 @@ export class LibraryController implements Disposable {
                 canSelectFiles: true,
                 canSelectFolders: true,
                 canSelectMany: true,
-                openLabel: "Select",
+                openLabel: "Select a jar file or directory to the project classpath",
             });
             if (!results) {
                 return;

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -49,7 +49,9 @@ export class LibraryController implements Disposable {
                 return;
             }
             libraryGlobs = await Promise.all(results.map(async (uri: Uri) => {
-                const uriPath = workspace.asRelativePath(uri);
+                // keep the param: `includeWorkspaceFolder` to false here
+                // since the multi-root is not supported well for invisible projects
+                const uriPath = workspace.asRelativePath(uri, false);
                 return (await fse.stat(uri.fsPath)).isDirectory() ? `${uriPath}/**/*.jar` : uriPath;
             }));
         }
@@ -62,7 +64,7 @@ export class LibraryController implements Disposable {
 
     public async removeLibrary(library: string) {
         const setting = Settings.referencedLibraries();
-        setting.exclude = this.updatePatternArray(setting.exclude, workspace.asRelativePath(library));
+        setting.exclude = this.updatePatternArray(setting.exclude, workspace.asRelativePath(library, false));
         Settings.updateReferencedLibraries(setting);
     }
 

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -51,18 +51,18 @@ export class LibraryController implements Disposable {
                 return (await fse.stat(uri.fsPath)).isDirectory() ? `${uriPath}/**/*.jar` : uriPath;
             }));
         }
+
         const setting = Settings.referencedLibraries();
-        const excludeSet = new Set<string>(setting.exclude);
-        for (const excludePattern of excludeSet) {
+        setting.exclude = setting.exclude.filter((pattern) => {
             for (const includePatthern of libraryGlobs) {
-                if (minimatch(excludePattern, includePatthern)) {
-                    excludeSet.delete(excludePattern);
-                    break;
+                if (minimatch(pattern, includePatthern)) {
+                    return false;
                 }
             }
-        }
+            return true;
+        });
+
         setting.include = this.updateSettingArray(setting.include, ...libraryGlobs);
-        setting.exclude = Array.from(excludeSet);
         Settings.updateReferencedLibraries(setting);
     }
 

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -50,9 +50,6 @@ export class LibraryController implements Disposable {
             }));
         }
         const setting = Settings.referencedLibraries();
-        if (Settings.isDefaultReferencedLibraries()) {
-            setting.include = [];
-        }
         setting.include.push(...libraryGlobs);
         Settings.updateReferencedLibraries(setting);
     }

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -4,13 +4,19 @@
 import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as path from "path";
-import { commands, ExtensionContext, Uri, window, workspace } from "vscode";
+import { commands, Disposable, ExtensionContext, Uri, window, workspace } from "vscode";
+import { instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import * as xml2js from "xml2js";
+import { Commands } from "../commands";
 import { Utility } from "../utility";
 
-export class ProjectController {
-    constructor(public readonly context: ExtensionContext) {
+export class ProjectController implements Disposable {
+    public constructor(public readonly context: ExtensionContext) {
+        context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_CREATE,
+            instrumentOperation(Commands.JAVA_PROJECT_CREATE, () => this.createJavaProject())));
     }
+
+    public dispose() {}
 
     public async createJavaProject() {
         const javaVersion: number = await this.getJavaVersion();

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -11,12 +11,19 @@ import { Commands } from "../commands";
 import { Utility } from "../utility";
 
 export class ProjectController implements Disposable {
+
+    private disposable: Disposable;
+
     public constructor(public readonly context: ExtensionContext) {
-        context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_CREATE,
-            instrumentOperation(Commands.JAVA_PROJECT_CREATE, () => this.createJavaProject())));
+        this.disposable = Disposable.from(
+            commands.registerCommand(Commands.JAVA_PROJECT_CREATE,
+                instrumentOperation(Commands.JAVA_PROJECT_CREATE, () => this.createJavaProject())),
+        );
     }
 
-    public dispose() {}
+    public dispose() {
+        this.disposable.dispose();
+    }
 
     public async createJavaProject() {
         const javaVersion: number = await this.getJavaVersion();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 import { commands, ExtensionContext } from "vscode";
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "./commands";
+import { LibraryController } from "./controllers/libraryController";
 import { ProjectController } from "./controllers/projectController";
 import { Services } from "./services";
 import { Settings } from "./settings";
@@ -20,10 +21,8 @@ function activateExtension(operationId: string, context: ExtensionContext) {
     Services.initialize(context);
     Settings.initialize(context);
 
-    const projectController: ProjectController = new ProjectController(context);
-    const instrumented = instrumentOperation(Commands.JAVA_PROJECT_CREATE, () => projectController.createJavaProject());
-    context.subscriptions.push(commands.registerCommand(Commands.JAVA_PROJECT_CREATE, instrumented));
-
+    context.subscriptions.push(new ProjectController(context));
+    context.subscriptions.push(new LibraryController(context));
     context.subscriptions.push(new DependencyExplorer(context));
 }
 

--- a/src/java/jdtls.ts
+++ b/src/java/jdtls.ts
@@ -10,6 +10,10 @@ export namespace Jdtls {
         return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_LIST, params);
     }
 
+    export function refreshLibraries(params): Thenable<boolean> {
+        return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_REFRESH_LIB_SERVER, params);
+    }
+
     export function getPackageData(params): Thenable<INodeData[]> {
         return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_GETPACKAGEDATA, params);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-    commands, ConfigurationChangeEvent, Disposable, DocumentHighlight, ExtensionContext,
-    window, workspace, WorkspaceConfiguration,
+    commands, ConfigurationChangeEvent, ExtensionContext,
+    workspace, WorkspaceConfiguration,
 } from "vscode";
 import { instrumentOperation } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "./commands";
@@ -73,6 +73,33 @@ export class Settings {
         workspace.getConfiguration().update("java.dependency.packagePresentation", PackagePresentation.Hierarchical, false);
     }
 
+    public static updateReferencedLibraries(setting: IReferencedLibraries): void {
+        let updateSetting: string[] | Partial<IReferencedLibraries> = {
+            include: setting.include,
+            exclude: setting.exclude.length > 0 ? setting.exclude : undefined,
+            sources: Object.keys(setting.sources).length > 0 ? setting.sources : undefined,
+        };
+        if (!updateSetting.exclude && !updateSetting.sources) {
+            updateSetting = setting.include;
+        }
+        workspace.getConfiguration().update("java.project.referencedLibraries", updateSetting);
+    }
+
+    public static referencedLibraries(): IReferencedLibraries {
+        const setting = workspace.getConfiguration("java.project").get<string[] | Partial<IReferencedLibraries>>("referencedLibraries");
+        const defaultSetting: IReferencedLibraries = { include: [], exclude: [], sources: {} };
+        if (Array.isArray(setting)) {
+            return { ...defaultSetting, include: setting };
+        } else {
+            return { ...defaultSetting, ...setting };
+        }
+    }
+
+    public static isDefaultReferencedLibraries(): boolean {
+        const setting = workspace.getConfiguration("java.project").inspect<string[] | Partial<IReferencedLibraries>>("referencedLibraries");
+        return setting.defaultValue && !setting.globalValue && !setting.workspaceValue && !setting.workspaceFolderValue;
+    }
+
     public static showOutline(): boolean {
         return this._dependencyConfig.get("showOutline");
     }
@@ -104,3 +131,9 @@ enum PackagePresentation {
 }
 
 type Listener = (updatedConfig: WorkspaceConfiguration, oldConfig: WorkspaceConfiguration) => void;
+
+export interface IReferencedLibraries {
+    include: string[];
+    exclude: string[];
+    sources: { [binary: string]: string };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,14 +73,14 @@ export class Settings {
         workspace.getConfiguration().update("java.dependency.packagePresentation", PackagePresentation.Hierarchical, false);
     }
 
-    public static updateReferencedLibraries(setting: IReferencedLibraries): void {
+    public static updateReferencedLibraries(libraries: IReferencedLibraries): void {
         let updateSetting: string[] | Partial<IReferencedLibraries> = {
-            include: setting.include,
-            exclude: setting.exclude.length > 0 ? setting.exclude : undefined,
-            sources: Object.keys(setting.sources).length > 0 ? setting.sources : undefined,
+            include: libraries.include,
+            exclude: libraries.exclude.length > 0 ? libraries.exclude : undefined,
+            sources: Object.keys(libraries.sources).length > 0 ? libraries.sources : undefined,
         };
         if (!updateSetting.exclude && !updateSetting.sources) {
-            updateSetting = setting.include;
+            updateSetting = libraries.include;
         }
         workspace.getConfiguration().update("java.project.referencedLibraries", updateSetting);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -95,11 +95,6 @@ export class Settings {
         }
     }
 
-    public static isDefaultReferencedLibraries(): boolean {
-        const setting = workspace.getConfiguration("java.project").inspect<string[] | Partial<IReferencedLibraries>>("referencedLibraries");
-        return setting.defaultValue && !setting.globalValue && !setting.workspaceValue && !setting.workspaceFolderValue;
-    }
-
     public static showOutline(): boolean {
         return this._dependencyConfig.get("showOutline");
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,9 +34,6 @@ const config = {
             use: [{
                 loader: 'ts-loader',
             }]
-        }, {
-            test: /\.node$/,
-            loader: 'native-ext-loader',
         }]
     },
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,9 @@ const config = {
             use: [{
                 loader: 'ts-loader',
             }]
+        }, {
+            test: /\.node$/,
+            loader: 'native-ext-loader',
         }]
     },
 }


### PR DESCRIPTION
Fix #174, https://github.com/microsoft/vscode-java-pack/issues/94 

Based on:
- [x] https://github.com/eclipse/eclipse.jdt.ls/pull/1267
- [x] #212
- [x] #215 

VS Code will take care of the file watching and searching work by providng a setting:

   ```typescript
   "java.dependency.referencedLibraries": string[] | {
     "include": string[],
     "exclude": string[],
     "sources": { [binary: string]: string }
   }
   ```

   ...with the following extended behaviors before sending to `jdt.ls`:

   * If specified setting is an array, it will be expanded into a full object, with the original content as `include` field. 
   * Jars in `lib/` but not `included` will be appended to `exclude` field. It is to ensure jars not listened by VS Code don't get shown in referenced libraries — only one source of truth. (This is not an elegent workaround, waiting for better alternative...)
   * A match of `foo.jar` and `foo-src.jar` (not necessarily in the same folder) will be added to sources mapping.