### PR TITLE
faet: Add dependency to Maven projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,15 @@
         }
       },
       {
+        "command": "java.project.maven.addDependency",
+        "title": "%contributes.commands.java.project.maven.addDependency%",
+        "category": "Java",
+        "icon": {
+          "dark": "images/dark/icon-add.svg",
+          "light": "images/light/icon-add.svg"
+        }
+      },
+      {
         "command": "java.project.removeLibrary",
         "title": "%contributes.commands.java.project.removeLibrary%",
         "category": "Java",
@@ -177,6 +186,14 @@
           "when": "never"
         },
         {
+          "command": "java.project.addLibraries",
+          "when": "never"
+        },
+        {
+          "command": "java.project.maven.addDependency",
+          "when": "never"
+        },
+        {
           "command": "java.project.removeLibrary",
           "when": "never"
         },
@@ -242,6 +259,11 @@
           "command": "java.project.refreshLibraries",
           "when": "view == javaDependencyExplorer && viewItem =~ /java:container\/referenced-libraries$/",
           "group": "inline@1"
+        },
+        {
+          "command": "java.project.maven.addDependency",
+          "when": "view == javaDependencyExplorer && viewItem =~ /container\/maven-dependencies/",
+          "group": "inline@0"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
   "description": "Manage Java Dependencies in VSCode",
   "contributes.commands.java.project.create": "Create Java Project",
   "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project classpath",
+  "contributes.commands.java.project.maven.addDependency": "Add a new dependency to the Maven project",
   "contributes.commands.java.project.removeLibrary": "Remove jar file from project classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.view.package.changeRepresentation": "Change package representation",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -2,6 +2,7 @@
   "description": "在 VSCode 中管理 Java 依赖项",
   "contributes.commands.java.project.create": "创建 Java 项目",
   "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目类路径中",
+  "contributes.commands.java.project.maven.addDependency": "为该 Maven 项目增加依赖库",
   "contributes.commands.java.project.removeLibrary": "将该 Jar 文件从 Java 项目类路径中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.view.package.changeRepresentation": "更改包展示形式",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,6 +38,8 @@ export namespace Commands {
 
     export const JAVA_PROJECT_REFRESH_LIBRARIES = "java.project.refreshLibraries";
 
+    export const JAVA_MAVEN_PROJECT_ADD_DEPENDENCY = "java.project.maven.addDependency";
+
     export const JAVA_PROJECT_LIST = "java.project.list";
 
     export const JAVA_PROJECT_REFRESH_LIB_SERVER = "java.project.refreshLib";

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -5,12 +5,13 @@ import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as minimatch from "minimatch";
 import * as path from "path";
-import { Disposable, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from "vscode";
+import { commands, Disposable, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
 import { Jdtls } from "../java/jdtls";
 import { Settings } from "../settings";
 import { Utility } from "../utility";
+import { ContainerNode } from "../views/containerNode";
 import { DataNode } from "../views/dataNode";
 
 export class LibraryController implements Disposable {
@@ -24,11 +25,22 @@ export class LibraryController implements Disposable {
                 this.removeLibrary(Uri.parse(node.uri).fsPath)),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_REFRESH_LIBRARIES, () =>
                 this.refreshLibraries()),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_MAVEN_PROJECT_ADD_DEPENDENCY, (node: ContainerNode) =>
+                this.addMavenDependency(node)),
         );
     }
 
     public dispose() {
         this.disposable.dispose();
+    }
+
+    public async addMavenDependency(node: ContainerNode) {
+        const pomPath: string = path.join(node.projectBasePath, "pom.xml");
+        if (await fse.pathExists(pomPath)) {
+            commands.executeCommand("maven.project.addDependency", { pomPath });
+        } else {
+            commands.executeCommand("maven.project.addDependency");
+        }
     }
 
     public async addLibraries(libraryGlobs?: string[]) {

--- a/src/views/containerNode.ts
+++ b/src/views/containerNode.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { Uri } from "vscode";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { DataNode } from "./dataNode";
@@ -11,6 +12,10 @@ import { ProjectNode } from "./projectNode";
 export class ContainerNode extends DataNode {
     constructor(nodeData: INodeData, parent: DataNode, private readonly _project: ProjectNode) {
         super(nodeData, parent);
+    }
+
+    public get projectBasePath() {
+        return Uri.parse(this._project.uri).fsPath;
     }
 
     protected loadData(): Thenable<INodeData[]> {


### PR DESCRIPTION
Register a command into the `Maven Dependencies` node and it will call the real command provided by `VS Code Maven`

![Kapture 2020-02-03 at 15 04 30](https://user-images.githubusercontent.com/6193897/73632529-e937ac00-4696-11ea-8f75-fa4525678965.gif)
