### PR TITLE
bugfix: Stop calling 'java.getPackageData' when the dependency explorer is not visible

### DIFF
--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { ExtensionContext, TextEditor, TreeView, TreeViewVisibilityChangeEvent, Uri, window } from "vscode";
+import { Disposable, ExtensionContext, TextEditor, TreeView, TreeViewVisibilityChangeEvent, Uri, window } from "vscode";
 import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
 import { Settings } from "../settings";
@@ -9,39 +9,45 @@ import { DataNode } from "./dataNode";
 import { DependencyDataProvider } from "./dependencyDataProvider";
 import { ExplorerNode } from "./explorerNode";
 
-export class DependencyExplorer {
+export class DependencyExplorer implements Disposable {
 
     private _dependencyViewer: TreeView<ExplorerNode>;
 
     private _dataProvider: DependencyDataProvider;
 
-    private _selectionWhenHidden: DataNode;
-
     constructor(public readonly context: ExtensionContext) {
         this._dataProvider = new DependencyDataProvider(context);
         this._dependencyViewer = window.createTreeView("javaDependencyExplorer", { treeDataProvider: this._dataProvider, showCollapseAll: true });
 
-        window.onDidChangeActiveTextEditor((textEditor: TextEditor) => {
-            if (textEditor && textEditor.document && Settings.syncWithFolderExplorer()) {
-                this.reveal(textEditor.document.uri);
-            }
-        });
+        context.subscriptions.push(
+            window.onDidChangeActiveTextEditor((textEditor: TextEditor) => {
+                if (this._dependencyViewer.visible && textEditor && textEditor.document && Settings.syncWithFolderExplorer()) {
+                    this.reveal(textEditor.document.uri);
+                }
+            }),
+        );
 
-        this._dependencyViewer.onDidChangeVisibility((e: TreeViewVisibilityChangeEvent) => {
-            if (e.visible && this._selectionWhenHidden) {
-                this._dependencyViewer.reveal(this._selectionWhenHidden);
-                this._selectionWhenHidden = undefined;
-            }
-        });
+        context.subscriptions.push(
+            this._dependencyViewer.onDidChangeVisibility((e: TreeViewVisibilityChangeEvent) => {
+                if (e.visible && window.activeTextEditor && Settings.syncWithFolderExplorer()) {
+                    this.reveal(window.activeTextEditor.document.uri);
+                }
+            }),
+        );
 
-        this._dataProvider.onDidChangeTreeData(() => {
-            if (window.activeTextEditor && Settings.syncWithFolderExplorer()) {
-                this.reveal(window.activeTextEditor.document.uri);
-            }
-        });
+        context.subscriptions.push(
+            this._dataProvider.onDidChangeTreeData(() => {
+                if (window.activeTextEditor && Settings.syncWithFolderExplorer()) {
+                    this.reveal(window.activeTextEditor.document.uri);
+                }
+            }),
+        );
     }
 
     public dispose(): void {
+        if (this._dependencyViewer) {
+            this._dependencyViewer.dispose();
+        }
     }
 
     public async reveal(uri: Uri): Promise<void> {
@@ -53,8 +59,6 @@ export class DependencyExplorer {
 
         if (this._dependencyViewer.visible) {
             this._dependencyViewer.reveal(node);
-        } else {
-            this._selectionWhenHidden = node;
         }
     }
 }


### PR DESCRIPTION
fix #231

1. check `this._dependencyViewer.visible` in `window.onDidChangeActiveTextEditor` to avoid redundant invocation of `java.getPackageData`

2. Put disposables into subscriptions

3. Directly call `reveal` when the visibility of the explorer changed. No need to cache `_selectionWhenHidden` anymore