### PR TITLE
Use JDK 11 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
-language: node_js
+language: java
 
-node_js:
-- '--lts'
+matrix:
+  include:
+  - os: linux
+    dist: trusty
+    jdk: openjdk11
+    env:
+      - JDK_HOME=~/openjdk11 # force launching JLS using JDK11
+  - os: osx
+    osx_image: xcode10.1
+    jdk: oraclejdk11
 
-os:
-- linux
-- osx
-
-dist: trusty
-osx_image: xcode9.3
+addons:
+  apt:
+    packages:
+    - libsecret-1-dev
 
 before_install:
   - |


### PR DESCRIPTION
VS Code Java requires JDK 11 to launch now.