### PR TITLE
Fix bug when no main method

### DIFF
--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -32,7 +32,8 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                     return reject();
                 });
                 const destPath = join(stepMetadata.workspaceUri.fsPath, basename(stepMetadata.workspaceUri.fsPath) + ".jar");
-                const exportResult = await Jdtls.exportJar(basename(stepMetadata.selectedMainMethod), stepMetadata.elements, destPath);
+                const mainMethod = (stepMetadata.selectedMainMethod === undefined) ? "" : basename(stepMetadata.selectedMainMethod);
+                const exportResult = await Jdtls.exportJar(mainMethod, stepMetadata.elements, destPath);
                 if (exportResult === true) {
                     stepMetadata.outputPath = destPath;
                     return resolve(true);

--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -32,8 +32,7 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                     return reject();
                 });
                 const destPath = join(stepMetadata.workspaceUri.fsPath, basename(stepMetadata.workspaceUri.fsPath) + ".jar");
-                const mainMethod = (stepMetadata.selectedMainMethod === undefined) ? "" : basename(stepMetadata.selectedMainMethod);
-                const exportResult = await Jdtls.exportJar(mainMethod, stepMetadata.elements, destPath);
+                const exportResult = await Jdtls.exportJar(basename(stepMetadata.selectedMainMethod), stepMetadata.elements, destPath);
                 if (exportResult === true) {
                     stepMetadata.outputPath = destPath;
                     return resolve(true);

--- a/src/exportJarSteps/ResolveMainMethodExecutor.ts
+++ b/src/exportJarSteps/ResolveMainMethodExecutor.ts
@@ -46,6 +46,7 @@ export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
         }
         const noMainClassItem: IJarQuickPickItem = {
             label: "<without main class>",
+            description: "",
         };
         pickItems.push(noMainClassItem);
         const disposables: Disposable[] = [];

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { QuickInputButtons, QuickPick, QuickPickItem, window } from "vscode";
-import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 
 export interface IJarQuickPickItem extends QuickPickItem {
     uri?: string;


### PR DESCRIPTION
when no main method, set mainMethod to an empry string instead of using basename(string).