### PR TITLE
bugfix: Wrong package created under the default package

### DIFF
--- a/src/explorerCommands/new.ts
+++ b/src/explorerCommands/new.ts
@@ -49,7 +49,7 @@ function getNewFilePath(basePath: string, className: string): string {
 export async function newPackage(node: DataNode): Promise<void> {
     let defaultValue: string;
     let packageRootPath: string;
-    if (node.nodeData.kind === NodeKind.PackageRoot) {
+    if (node.nodeData.kind === NodeKind.PackageRoot || node.name === "default-package") {
         defaultValue = "";
         packageRootPath = Uri.parse(node.uri).fsPath;
     } else if (node.nodeData.kind === NodeKind.Package) {


### PR DESCRIPTION
fix #304 

Create package from a default package should have the same behavior as creating from package root