### PR TITLE
Refine the context value of the nodes in the project explorer

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -56,7 +56,6 @@ import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.UpdateClasspathJob;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences.ReferencedLibraries;
 
-import com.microsoft.jdtls.ext.core.model.NodeKind;
 import com.microsoft.jdtls.ext.core.model.PackageNode;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.CollectionTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EnumTypeAdapter;

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
@@ -41,6 +41,11 @@ import com.microsoft.jdtls.ext.core.JdtlsExtActivator;
  */
 public class PackageNode {
 
+    /**
+     * Nature Id for the IProject
+     */
+    private static final String NATURE_ID = "NatureId";
+
     public final static String K_TYPE_KIND = "TypeKind";
 
     /**
@@ -141,6 +146,11 @@ public class PackageNode {
         IProject proj = javaElement.getJavaProject().getProject();
         PackageNode projectNode = new PackageNode(proj.getName(), proj.getFullPath().toPortableString(), NodeKind.PROJECT);
         projectNode.setUri(proj.getLocationURI().toString());
+        try {
+            projectNode.setMetaDataValue(NATURE_ID, proj.getDescription().getNatureIds());
+        } catch (CoreException e) {
+            // do nothing
+        }
         return projectNode;
     }
 

--- a/package.json
+++ b/package.json
@@ -47,12 +47,6 @@
         "icon": "$(add)"
       },
       {
-        "command": "java.project.maven.addDependency",
-        "title": "%contributes.commands.java.project.maven.addDependency%",
-        "category": "Java",
-        "icon": "$(add)"
-      },
-      {
         "command": "java.project.removeLibrary",
         "title": "%contributes.commands.java.project.removeLibrary%",
         "category": "Java",
@@ -218,10 +212,6 @@
           "when": "never"
         },
         {
-          "command": "java.project.maven.addDependency",
-          "when": "never"
-        },
-        {
           "command": "java.project.removeLibrary",
           "when": "never"
         },
@@ -296,52 +286,47 @@
       "view/item/context": [
         {
           "command": "java.view.package.revealFileInOS",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:.*?\\+uri/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:(?=.*?\\b\\+uri\\b)/",
           "group": "path@10"
         },
         {
           "command": "java.view.package.copyFilePath",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:.*?\\+uri/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:(?=.*?\\b\\+uri\\b)/",
           "group": "path@20"
         },
         {
           "command": "java.view.package.copyRelativeFilePath",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:.*?\\+uri/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:(?=.*?\\b\\+uri\\b)/",
           "group": "path@25"
         },
         {
           "command": "java.view.package.newJavaClass",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:(package|packageRoot).*\\+uri/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+source\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "new@10"
         },
         {
           "command": "java.view.package.newPackage",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:(package|packageRoot).*\\+uri/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+source\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "new@20"
         },
         {
           "command": "java.project.addLibraries",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:container\/referenced-libraries$/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
           "group": "inline@0"
         },
         {
           "command": "java.project.removeLibrary",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:jar\/referenced-libraries\\+uri$/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:jar(?=.*?\\b\\+referencedLibrary\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "inline"
         },
         {
           "command": "java.project.refreshLibraries",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:container\/referenced-libraries$/",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
           "group": "inline@1"
         },
         {
-          "command": "java.project.maven.addDependency",
-          "when": "view == javaProjectExplorer && mavenEnabled && viewItem =~ /container\/maven-dependencies/",
-          "group": "inline@0"
-        },
-        {
           "command": "java.view.package.exportJar",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:workspace.*?\\+uri/ && java:serverMode!= LightWeight",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:workspace(?=.*?\\b\\+uri\\b)/ && java:serverMode!= LightWeight",
           "group": "inline"
         }
       ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,6 @@
   "description": "Manage Java projects in Visual Studio Code",
   "contributes.commands.java.project.create": "Create Java Project...",
   "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project classpath",
-  "contributes.commands.java.project.maven.addDependency": "Add a new dependency to the Maven project",
   "contributes.commands.java.project.removeLibrary": "Remove jar file from project classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.project.build.workspace": "Build Workspace",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -2,7 +2,6 @@
   "description": "在 Visual Studio Code 中管理 Java 项目",
   "contributes.commands.java.project.create": "创建 Java 项目...",
   "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目类路径中",
-  "contributes.commands.java.project.maven.addDependency": "为该 Maven 项目增加依赖库",
   "contributes.commands.java.project.removeLibrary": "将该 Jar 文件从 Java 项目类路径中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.project.build.workspace": "构建工作空间",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,8 +48,6 @@ export namespace Commands {
 
     export const JAVA_PROJECT_CLEAN_WORKSPACE = "java.project.clean.workspace";
 
-    export const JAVA_MAVEN_PROJECT_ADD_DEPENDENCY = "java.project.maven.addDependency";
-
     export const JAVA_MAVEN_CREATE_PROJECT = "maven.archetype.generate";
 
     export const JAVA_PROJECT_LIST = "java.project.list";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export namespace Context {
 export namespace Explorer {
     export const DEFAULT_PACKAGE_NAME: string = "default-package";
     export enum ContextValueType {
-        Workspace = "workspace",
+        WorkspaceFolder = "workspaceFolder",
         Project = "project",
         Container = "container",
         PackageRoot = "packageRoot",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export namespace Context {
 }
 
 export namespace Explorer {
-    export const DEFAULT_PACKAGE_NAME: string = "default-package";
+    export const DEFAULT_PACKAGE_NAME: string = "(default package)";
     export enum ContextValueType {
         WorkspaceFolder = "workspaceFolder",
         Project = "project",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,10 +2,17 @@
 // Licensed under the MIT license.
 
 export namespace Context {
-    export const MAVEN_ENABLED: string = "mavenEnabled";
     export const EXTENSION_ACTIVATED: string = "extensionActivated";
 }
 
 export namespace Explorer {
     export const DEFAULT_PACKAGE_NAME: string = "default-package";
+    export enum ContextValueType {
+        Workspace = "workspace",
+        Project = "project",
+        Container = "container",
+        PackageRoot = "packageRoot",
+        Package = "package",
+        Jar = "jar",
+    }
 }

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -25,8 +25,6 @@ export class LibraryController implements Disposable {
                 this.removeLibrary(Uri.parse(node.uri).fsPath)),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_REFRESH_LIBRARIES, () =>
                 this.refreshLibraries()),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_MAVEN_PROJECT_ADD_DEPENDENCY, (node: ContainerNode) =>
-                this.addMavenDependency(node)),
         );
     }
 

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -32,15 +32,6 @@ export class LibraryController implements Disposable {
         this.disposable.dispose();
     }
 
-    public async addMavenDependency(node: ContainerNode) {
-        const pomPath: string = path.join(node.projectBasePath, "pom.xml");
-        if (await fse.pathExists(pomPath)) {
-            commands.executeCommand("maven.project.addDependency", { pomPath });
-        } else {
-            commands.executeCommand("maven.project.addDependency");
-        }
-    }
-
     public async addLibraries(libraryGlobs?: string[]) {
         if (!libraryGlobs) {
             libraryGlobs = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,6 @@ async function activateExtension(_operationId: string, context: ExtensionContext
 
     Settings.initialize(context);
     contextManager.initialize(context);
-    setMavenExtensionState();
 
     context.subscriptions.push(new ProjectController(context));
     context.subscriptions.push(new LibraryController(context));
@@ -63,19 +62,6 @@ async function activateExtension(_operationId: string, context: ExtensionContext
     contextManager.setContextValue(Context.EXTENSION_ACTIVATED, true);
 
     initExpService(context);
-}
-
-// determine if the add dependency shortcut will show or not
-function setMavenExtensionState() {
-    setMavenEnabledContext();
-    extensions.onDidChange(() => {
-        setMavenEnabledContext();
-    });
-
-    function setMavenEnabledContext() {
-        const mavenExt: Extension<any> | undefined = extensions.getExtension("vscjava.vscode-maven");
-        contextManager.setContextValue(Context.MAVEN_ENABLED, !!mavenExt);
-    }
 }
 
 // this method is called when your extension is deactivated

--- a/src/java/nodeData.ts
+++ b/src/java/nodeData.ts
@@ -29,5 +29,5 @@ export interface INodeData {
     uri?: string;
     kind: NodeKind;
     children?: any[];
-    metaData?: Map<string, any>;
+    metaData?: { [id: string]: any };
 }

--- a/src/views/containerNode.ts
+++ b/src/views/containerNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ThemeIcon, Uri } from "vscode";
+import { Explorer } from "../constants";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { DataNode } from "./dataNode";
@@ -33,10 +34,36 @@ export class ContainerNode extends DataNode {
     }
 
     protected get contextValue(): string {
-        return `container/${this.name}`;
+        let contextValue: string = Explorer.ContextValueType.Container;
+        const containerType: string = getContainerType(this._nodeData.path);
+        if (containerType) {
+            contextValue += `+${containerType}`;
+        }
+        return contextValue;
     }
 
     protected get iconPath(): ThemeIcon {
         return new ThemeIcon("library");
     }
+}
+
+function getContainerType(containerPath: string | undefined): string {
+    if (!containerPath) {
+        return "";
+    } else if (containerPath.startsWith(ContainerPath.JavaSE)) {
+        return "javaSE";
+    } else if (containerPath.startsWith(ContainerPath.Maven)) {
+        return "maven";
+    } else if (containerPath.startsWith(ContainerPath.Gradle)) {
+        return "gradle";
+    } else if (containerPath.startsWith(ContainerPath.ReferencedLibrary)) {
+        return "referencedLibrary";
+    }
+}
+
+const enum ContainerPath {
+    JavaSE = "org.eclipse.jdt.launching.JRE_CONTAINER",
+    Maven = "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER",
+    Gradle = "org.eclipse.buildship.core.gradleclasspathcontainer",
+    ReferencedLibrary = "REFERENCED_LIBRARIES_PATH",
 }

--- a/src/views/containerNode.ts
+++ b/src/views/containerNode.ts
@@ -50,8 +50,8 @@ export class ContainerNode extends DataNode {
 function getContainerType(containerPath: string | undefined): string {
     if (!containerPath) {
         return "";
-    } else if (containerPath.startsWith(ContainerPath.JavaSE)) {
-        return "javaSE";
+    } else if (containerPath.startsWith(ContainerPath.JRE)) {
+        return "jre";
     } else if (containerPath.startsWith(ContainerPath.Maven)) {
         return "maven";
     } else if (containerPath.startsWith(ContainerPath.Gradle)) {
@@ -62,7 +62,7 @@ function getContainerType(containerPath: string | undefined): string {
 }
 
 const enum ContainerPath {
-    JavaSE = "org.eclipse.jdt.launching.JRE_CONTAINER",
+    JRE = "org.eclipse.jdt.launching.JRE_CONTAINER",
     Maven = "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER",
     Gradle = "org.eclipse.buildship.core.gradleclasspathcontainer",
     ReferencedLibrary = "REFERENCED_LIBRARIES_PATH",

--- a/src/views/dataNode.ts
+++ b/src/views/dataNode.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as _ from "lodash";
 import { ProviderResult, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import { INodeData } from "../java/nodeData";
 import { ExplorerNode } from "./explorerNode";
@@ -41,8 +40,8 @@ export abstract class DataNode extends ExplorerNode {
         return this._nodeData.handlerIdentifier;
     }
 
-    public get name() { // return name like `referenced-library`
-        return _.kebabCase(this._nodeData.name);
+    public get name() {
+        return this._nodeData.name;
     }
 
     public async revealPaths(paths: INodeData[]): Promise<DataNode> {

--- a/src/views/packageNode.ts
+++ b/src/views/packageNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ThemeIcon } from "vscode";
+import { Explorer } from "../constants";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { IPackageRootNodeData, PackageRootKind } from "../java/packageRootNodeData";
@@ -49,7 +50,9 @@ export class PackageNode extends DataNode {
     protected get contextValue(): string {
         const parentData = <IPackageRootNodeData> this._rootNode.nodeData;
         if (parentData.entryKind === PackageRootKind.K_SOURCE) {
-            return `package/${this.name}`;
+            return `${Explorer.ContextValueType.Package}+source`;
+        } else if (parentData.entryKind === PackageRootKind.K_BINARY) {
+            return `${Explorer.ContextValueType.Package}+binary`;
         }
     }
 }

--- a/src/views/packageRootNode.ts
+++ b/src/views/packageRootNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ThemeIcon } from "vscode";
+import { Explorer } from "../constants";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { IPackageRootNodeData, PackageRootKind } from "../java/packageRootNodeData";
@@ -62,13 +63,19 @@ export class PackageRootNode extends DataNode {
     protected get contextValue(): string {
         const data = <IPackageRootNodeData>this.nodeData;
         if (data.entryKind === PackageRootKind.K_BINARY) {
+            let contextValue: string = Explorer.ContextValueType.Jar;
             const parent = <ContainerNode>this.getParent();
-            return `jar/${parent.name}`;
-        } else if (!resourceRoots.includes(this._nodeData.name)) {
+            if (parent.path.startsWith("REFERENCED_LIBRARIES_PATH")) {
+                contextValue += "+referencedLibrary";
+            }
+            return contextValue;
+        } else if (resourceRoots.includes(this._nodeData.name)) {
             // APIs in JDT does not have a consistent result telling whether a package root
             // is a source root or resource root, so we hard code some common resources root
             // here as a workaround.
-            return `packageRoot/${this.name}`;
+            return `${Explorer.ContextValueType.PackageRoot}+resource`;
+        } else {
+            return `${Explorer.ContextValueType.PackageRoot}+source`;
         }
     }
 

--- a/src/views/projectNode.ts
+++ b/src/views/projectNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ThemeIcon } from "vscode";
+import { Explorer } from "../constants";
 import { ContainerEntryKind, IContainerNodeData } from "../java/containerNodeData";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
@@ -69,7 +70,52 @@ export class ProjectNode extends DataNode {
     protected get iconPath(): ThemeIcon {
         return new ThemeIcon("project");
     }
+
     protected get contextValue(): string {
-        return `project/${this.name}`;
+        let contextValue: string = Explorer.ContextValueType.Project;
+        const natureIds: string[] | undefined = this.nodeData.metaData[NATURE_ID];
+        if (natureIds) {
+            const attributeString: string = getProjectTypeAttributes(natureIds);
+            contextValue += attributeString;
+        }
+        return contextValue;
     }
 }
+
+function getProjectTypeAttributes(natureIds: string []): string {
+    let attributeString: string = "";
+    for (const natureId of natureIds) {
+        const readableNature: string = getProjectType(natureId);
+        if (readableNature) {
+            attributeString += `+${readableNature}`;
+        }
+    }
+    return attributeString;
+}
+
+function getProjectType(natureId: string): string {
+    switch (natureId) {
+        case NatureId.Java:
+            return ReadableNature.Java;
+        case NatureId.Maven:
+            return ReadableNature.Maven;
+        case NatureId.Gradle:
+            return ReadableNature.Gradle;
+        default:
+            return "";
+    }
+}
+
+enum NatureId {
+    Maven = "org.eclipse.m2e.core.maven2Nature",
+    Gradle = "org.eclipse.buildship.core.gradleprojectnature",
+    Java = "org.eclipse.jdt.core.javanature",
+}
+
+enum ReadableNature {
+    Maven = "maven",
+    Gradle = "gradle",
+    Java = "java",
+}
+
+const NATURE_ID = "NatureId";

--- a/src/views/workspaceNode.ts
+++ b/src/views/workspaceNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { ThemeIcon } from "vscode";
+import { Explorer } from "../constants";
 import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
 import { DataNode } from "./dataNode";
@@ -30,7 +31,8 @@ export class WorkspaceNode extends DataNode {
     protected get iconPath(): ThemeIcon {
         return new ThemeIcon("root-folder");
     }
+
     protected get contextValue(): string {
-        return `workspace/${this.name}`;
+        return Explorer.ContextValueType.Workspace;
     }
 }

--- a/src/views/workspaceNode.ts
+++ b/src/views/workspaceNode.ts
@@ -33,6 +33,6 @@ export class WorkspaceNode extends DataNode {
     }
 
     protected get contextValue(): string {
-        return Explorer.ContextValueType.Workspace;
+        return Explorer.ContextValueType.WorkspaceFolder;
     }
 }

--- a/test/explorer/contextValue.test.ts
+++ b/test/explorer/contextValue.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { Uri } from "vscode";
+import { INodeData, NodeKind } from "../../src/java/nodeData";
+import { PackageRootKind } from "../../src/java/packageRootNodeData";
+import { ContainerNode } from "../../src/views/containerNode";
+import { PackageNode } from "../../src/views/packageNode";
+import { PackageRootNode } from "../../src/views/packageRootNode";
+import { ProjectNode } from "../../src/views/projectNode";
+import { WorkspaceNode } from "../../src/views/workspaceNode";
+
+// tslint:disable: only-arrow-functions
+// tslint:disable: no-object-literal-type-assertion
+suite("Context Value Tests", () => {
+
+    test("test workspace node", async function() {
+        assert.equal((await workspace.getTreeItem()).contextValue, "java:workspace+uri");
+    });
+
+    test("test Maven project node", async function() {
+        assert.equal((await mavenProject.getTreeItem()).contextValue, "java:project+java+maven+uri");
+    });
+
+    test("test Gradle project node", async function() {
+        assert.equal((await gradleProject.getTreeItem()).contextValue, "java:project+java+gradle+uri");
+    });
+
+    test("test JavaSE container node", async function() {
+        assert.equal((await javaSEContainer.getTreeItem()).contextValue, "java:container+javaSE+uri");
+    });
+
+    test("test Maven container node", async function() {
+        assert.equal((await mavenContainer.getTreeItem()).contextValue, "java:container+maven+uri");
+    });
+
+    test("test Gradle container node", async function() {
+        assert.equal((await gradleContainer.getTreeItem()).contextValue, "java:container+gradle+uri");
+    });
+
+    test("test Referenced Libraries container node", async function() {
+        assert.equal((await referencedLibrariesContainer.getTreeItem()).contextValue, "java:container+referencedLibrary+uri");
+    });
+
+    test("test source root node", async function() {
+        assert.equal((await sourceRoot.getTreeItem()).contextValue, "java:packageRoot+source+uri");
+    });
+
+    test("test resource root node", async function() {
+        assert.equal((await resourceRoot.getTreeItem()).contextValue, "java:packageRoot+resource+uri");
+    });
+
+    test("test dependency jar node", async function() {
+        assert.equal((await dependencyJar.getTreeItem()).contextValue, "java:jar+uri");
+    });
+
+    test("test referenced library jar node", async function() {
+        assert.equal((await referencedLibraryJar.getTreeItem()).contextValue, "java:jar+referencedLibrary+uri");
+    });
+
+    test("test source package node", async function() {
+        assert.equal((await sourcePackage.getTreeItem()).contextValue, "java:package+source+uri");
+    });
+
+    test("test binary package node", async function() {
+        assert.equal((await binaryPackage.getTreeItem()).contextValue, "java:package+binary+uri");
+    });
+});
+
+// below are faked nodes only for test purpose
+const workspace: WorkspaceNode = new WorkspaceNode({
+    name: "workspace",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Workspace,
+}, null);
+
+const mavenProject: ProjectNode = new ProjectNode({
+    name: "mavenProject",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Project,
+    metaData: {
+        NatureId: ["org.eclipse.jdt.core.javanature", "org.eclipse.m2e.core.maven2Nature"],
+    },
+}, workspace);
+
+const gradleProject: ProjectNode = new ProjectNode({
+    name: "gradleProject",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Project,
+    metaData: {
+        NatureId: ["org.eclipse.jdt.core.javanature", "org.eclipse.buildship.core.gradleprojectnature"],
+    },
+}, workspace);
+
+const javaSEContainer: ContainerNode = new ContainerNode({
+    name: "javaSEContainer",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Container,
+    path: "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11",
+}, mavenProject, mavenProject);
+
+const mavenContainer: ContainerNode = new ContainerNode({
+    name: "javaSEContainer",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Container,
+    path: "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER",
+}, mavenProject, mavenProject);
+
+const gradleContainer: ContainerNode = new ContainerNode({
+    name: "javaSEContainer",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Container,
+    path: "org.eclipse.buildship.core.gradleclasspathcontainer",
+}, gradleProject, gradleProject);
+
+const referencedLibrariesContainer: ContainerNode = new ContainerNode({
+    name: "javaSEContainer",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Container,
+    path: "REFERENCED_LIBRARIES_PATH",
+}, mavenProject, mavenProject);
+
+const sourceRoot: PackageRootNode = new PackageRootNode({
+    name: "src/main/java",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.PackageRoot,
+    entryKind: PackageRootKind.K_SOURCE,
+} as INodeData, mavenContainer, mavenProject);
+
+const resourceRoot: PackageRootNode = new PackageRootNode({
+    name: "src/main/resources",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.PackageRoot,
+    entryKind: PackageRootKind.K_SOURCE,
+} as INodeData, mavenContainer, mavenProject);
+
+const dependencyJar: PackageRootNode = new PackageRootNode({
+    name: "junit-4.12.jar",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.PackageRoot,
+    entryKind: PackageRootKind.K_BINARY,
+} as INodeData, mavenContainer, mavenProject);
+
+const referencedLibraryJar: PackageRootNode = new PackageRootNode({
+    name: "junit-4.12.jar",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.PackageRoot,
+    entryKind: PackageRootKind.K_BINARY,
+} as INodeData, referencedLibrariesContainer, mavenProject);
+
+const sourcePackage: PackageNode = new PackageNode({
+    name: "com.microsoft.java",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Package,
+}, sourceRoot, mavenProject, sourceRoot);
+
+const binaryPackage: PackageNode = new PackageNode({
+    name: "junit",
+    uri: Uri.file(__dirname).toString(),
+    kind: NodeKind.Package,
+}, dependencyJar, mavenProject, dependencyJar);

--- a/test/explorer/contextValue.test.ts
+++ b/test/explorer/contextValue.test.ts
@@ -27,8 +27,8 @@ suite("Context Value Tests", () => {
         assert.equal((await gradleProject.getTreeItem()).contextValue, "java:project+java+gradle+uri");
     });
 
-    test("test JavaSE container node", async function() {
-        assert.equal((await javaSEContainer.getTreeItem()).contextValue, "java:container+javaSE+uri");
+    test("test JRE container node", async function() {
+        assert.equal((await jreContainer.getTreeItem()).contextValue, "java:container+jre+uri");
     });
 
     test("test Maven container node", async function() {
@@ -93,29 +93,29 @@ const gradleProject: ProjectNode = new ProjectNode({
     },
 }, workspace);
 
-const javaSEContainer: ContainerNode = new ContainerNode({
-    name: "javaSEContainer",
+const jreContainer: ContainerNode = new ContainerNode({
+    name: "jreContainer",
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.Container,
     path: "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11",
 }, mavenProject, mavenProject);
 
 const mavenContainer: ContainerNode = new ContainerNode({
-    name: "javaSEContainer",
+    name: "mavenContainer",
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.Container,
     path: "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER",
 }, mavenProject, mavenProject);
 
 const gradleContainer: ContainerNode = new ContainerNode({
-    name: "javaSEContainer",
+    name: "gradleContainer",
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.Container,
     path: "org.eclipse.buildship.core.gradleclasspathcontainer",
 }, gradleProject, gradleProject);
 
 const referencedLibrariesContainer: ContainerNode = new ContainerNode({
-    name: "javaSEContainer",
+    name: "referencedLibrariesContainer",
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.Container,
     path: "REFERENCED_LIBRARIES_PATH",

--- a/test/explorer/contextValue.test.ts
+++ b/test/explorer/contextValue.test.ts
@@ -16,7 +16,7 @@ import { WorkspaceNode } from "../../src/views/workspaceNode";
 suite("Context Value Tests", () => {
 
     test("test workspace node", async function() {
-        assert.equal((await workspace.getTreeItem()).contextValue, "java:workspace+uri");
+        assert.equal((await workspace.getTreeItem()).contextValue, "java:workspaceFolder+uri");
     });
 
     test("test Maven project node", async function() {


### PR DESCRIPTION
This PR is to better expose the node context value.

### Context Value Format
`java:<node type>[+<attribute>]*`

### Available Node Types:
Currently, available node types are:
- `workspaceFolder`
- `project`
- `container`
- `packageRoot`
- `package`
- `jar`

Not available node types are:
- `folder`
- `file`
- `type` (class, enum, interface,...)

Below picture illustrates the different node types
![image](https://user-images.githubusercontent.com/6193897/91000101-f4363780-e5fa-11ea-9190-44799dd7bd38.png)

### Attributes:
For each node type, it may have some attributes. Every attribute will start with a `+`.

#### Common Attributes:
- `+uri`: The node has uri

#### Specific Attributes:
**Project Node**:
- `+java`: Java project
- `+maven`: Maven project
- `+gradle`: Gradle project

**Container Node**:
- `+jre`: Container for JRE
- `+maven`: Container for Maven
- `+gradle`: Container for Gradle
- `+referencedLibrary`: Container for Referenced Libraries

**Package Root Node**:
- `+source`: Source package root.
- `+resource`: Resource package root

**Package Node**:
- `+source`: Source package
- `+binary`: Binary package (Expanded inside a binary jar)

**Jar Node**:
- `+referencedLibrary`: Referenced Library jar

### Usage example:
For example, A node for a Maven project may have the following context value:

```
java:project+maven+uri
```

If you want to register a command on that node, you can write your when clause as:

```
"when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+maven\\b)(?=.*?\\b\\+uri\\b)/",
```