### PR TITLE
Directly show children under default package

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
@@ -69,7 +69,6 @@ public class PackageNode {
     private static final String IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER_NAME = "Referenced Libraries (Read-only)";
 
     public static final String REFERENCED_LIBRARIES_PATH = "REFERENCED_LIBRARIES_PATH";
-    public static final String DEFAULT_PACKAGE_DISPLAYNAME = "(default package)";
     public static final ContainerNode REFERENCED_LIBRARIES_CONTAINER = new ContainerNode(REFERENCED_LIBRARIES_CONTAINER_NAME, REFERENCED_LIBRARIES_PATH,
             NodeKind.CONTAINER, IClasspathEntry.CPE_CONTAINER);
     public static final ContainerNode IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER = new ContainerNode(IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER_NAME,
@@ -177,8 +176,7 @@ public class PackageNode {
     }
 
     public static PackageNode createNodeForPackageFragment(IPackageFragment packageFragment) {
-        String packageName = packageFragment.isDefaultPackage() ? DEFAULT_PACKAGE_DISPLAYNAME : packageFragment.getElementName();
-        PackageNode fragmentNode = new PackageNode(packageName, packageFragment.getPath().toPortableString(), NodeKind.PACKAGE);
+        PackageNode fragmentNode = new PackageNode(packageFragment.getElementName(), packageFragment.getPath().toPortableString(), NodeKind.PACKAGE);
         fragmentNode.setHandlerIdentifier(packageFragment.getHandleIdentifier());
         return fragmentNode;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,6 @@ export namespace Context {
 }
 
 export namespace Explorer {
-    export const DEFAULT_PACKAGE_NAME: string = "(default package)";
     export enum ContextValueType {
         WorkspaceFolder = "workspaceFolder",
         Project = "project",

--- a/src/explorerCommands/new.ts
+++ b/src/explorerCommands/new.ts
@@ -4,7 +4,6 @@
 import * as fse from "fs-extra";
 import * as path from "path";
 import { Uri, window, workspace, WorkspaceEdit } from "vscode";
-import { Explorer } from "../constants";
 import { NodeKind } from "../java/nodeData";
 import { isJavaIdentifier, isKeyword } from "../utility";
 import { DataNode } from "../views/dataNode";
@@ -50,7 +49,7 @@ function getNewFilePath(basePath: string, className: string): string {
 export async function newPackage(node: DataNode): Promise<void> {
     let defaultValue: string;
     let packageRootPath: string;
-    if (node.nodeData.kind === NodeKind.PackageRoot || node.name === Explorer.DEFAULT_PACKAGE_NAME) {
+    if (node.nodeData.kind === NodeKind.PackageRoot) {
         defaultValue = "";
         packageRootPath = Uri.parse(node.uri).fsPath;
     } else if (node.nodeData.kind === NodeKind.Package) {

--- a/src/views/nodeCache/explorerNodeCache.ts
+++ b/src/views/nodeCache/explorerNodeCache.ts
@@ -3,7 +3,6 @@
 
 import * as path from "path";
 import { Uri } from "vscode";
-import { Explorer } from "../../constants";
 import { DataNode } from "../dataNode";
 import { ExplorerNode } from "../explorerNode";
 import { Trie, TrieNode } from "./Trie";
@@ -28,9 +27,7 @@ class ExplorerNodeCache {
     }
 
     public saveNode(node: ExplorerNode): void {
-        // default package has the same uri as the root package,
-        // we skip default package and store the root package here.
-        if (node instanceof DataNode && node.uri && node.name !== Explorer.DEFAULT_PACKAGE_NAME) {
+        if (node instanceof DataNode && node.uri) {
             this.mutableNodeCache.insert(node);
         }
     }


### PR DESCRIPTION
Source with default package:
![1](https://user-images.githubusercontent.com/6193897/91685131-016b9d00-eb8c-11ea-9f89-68ed90ef45d7.png)


Binary with default package: (e.g. default package that stores the module-info.class)
![2](https://user-images.githubusercontent.com/6193897/91685159-16483080-eb8c-11ea-8c37-3f4870c4f7cc.png)

fix #313 