### PR TITLE
Specific target folder when exporting jar and enhancement of jdtls.ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,7 +1055,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -4128,7 +4129,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "liftoff": {
@@ -4764,6 +4766,29 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -4856,6 +4881,14 @@
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
       "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-windows": {
       "version": "0.2.0",
@@ -7797,7 +7830,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4766,29 +4766,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-invalid-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
-      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
-      "requires": {
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -4881,14 +4858,6 @@
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
       "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
-    },
-    "is-valid-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
-      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
-      "requires": {
-        "is-invalid-path": "^0.1.0"
-      }
     },
     "is-windows": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -179,13 +179,13 @@
           "description": "%configuration.java.dependency.packagePresentation%",
           "default": "flat"
         },
-        "java.project.exportjar.targetPath": {
+        "java.project.exportJar.targetPath": {
           "type": "string",
           "enum": [
             "${workspaceFolder}/${workspaceFolderBasename}.jar",
             "askUser"
           ],
-          "description": "%configuration.java.project.exportjar.targetPath%",
+          "description": "%configuration.java.project.exportJar.targetPath%",
           "default": "${workspaceFolder}/${workspaceFolderBasename}.jar"
         }
       }

--- a/package.json
+++ b/package.json
@@ -173,6 +173,15 @@
           ],
           "description": "%configuration.java.dependency.packagePresentation%",
           "default": "flat"
+        },
+        "java.dependency.exportjar.defaultTargetFolder": {
+          "type": "string",
+          "enum": [
+            "${workspaceFolder}/${workspaceFolderBasename}.jar",
+            "askUser"
+          ],
+          "description": "Specific the default output folder of export jar.",
+          "default": "${workspaceFolder}/${workspaceFolderBasename}.jar"
         }
       }
     },
@@ -435,6 +444,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
+    "is-valid-path": "0.1.1",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.20",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -444,7 +444,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "is-valid-path": "0.1.1",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.20",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -179,13 +179,13 @@
           "description": "%configuration.java.dependency.packagePresentation%",
           "default": "flat"
         },
-        "java.dependency.exportjar.targetPath": {
+        "java.project.exportjar.targetPath": {
           "type": "string",
           "enum": [
             "${workspaceFolder}/${workspaceFolderBasename}.jar",
             "askUser"
           ],
-          "description": "%configuration.java.dependency.exportjar.targetPath%",
+          "description": "%configuration.java.project.exportjar.targetPath%",
           "default": "${workspaceFolder}/${workspaceFolderBasename}.jar"
         }
       }

--- a/package.json
+++ b/package.json
@@ -179,13 +179,13 @@
           "description": "%configuration.java.dependency.packagePresentation%",
           "default": "flat"
         },
-        "java.dependency.exportjar.defaultTargetFolder": {
+        "java.dependency.exportjar.defaultTargetPath": {
           "type": "string",
           "enum": [
             "${workspaceFolder}/${workspaceFolderBasename}.jar",
             "askUser"
           ],
-          "description": "Specific the default output folder of export jar.",
+          "description": "%configuration.java.dependency.exportjar.defaultTargetPath%",
           "default": "${workspaceFolder}/${workspaceFolderBasename}.jar"
         }
       }

--- a/package.json
+++ b/package.json
@@ -179,13 +179,13 @@
           "description": "%configuration.java.dependency.packagePresentation%",
           "default": "flat"
         },
-        "java.dependency.exportjar.defaultTargetPath": {
+        "java.dependency.exportjar.targetPath": {
           "type": "string",
           "enum": [
             "${workspaceFolder}/${workspaceFolderBasename}.jar",
             "askUser"
           ],
-          "description": "%configuration.java.dependency.exportjar.defaultTargetPath%",
+          "description": "%configuration.java.dependency.exportjar.targetPath%",
           "default": "${workspaceFolder}/${workspaceFolderBasename}.jar"
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",
   "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected",
   "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical",
-  "configuration.java.dependency.exportjar.defaultTargetPath": "The default output path of export jar"
+  "configuration.java.dependency.exportjar.targetPath": "The default output path of export jar"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",
   "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected",
   "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical",
-  "configuration.java.project.exportjar.targetPath": "The default output path of export jar"
+  "configuration.java.project.exportJar.targetPath": "The default output path of export jar"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,5 +22,6 @@
   "configuration.java.dependency.syncWithFolderExplorer": "Synchronize Java Projects explorer selection with folder explorer",
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",
   "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected",
-  "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical"
+  "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical",
+  "configuration.java.dependency.exportjar.defaultTargetPath": "The default output path of export jar"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",
   "configuration.java.dependency.refreshDelay": "The delay time (ms) the auto refresh is invoked when changes are detected",
   "configuration.java.dependency.packagePresentation": "Package presentation mode: flat or hierarchical",
-  "configuration.java.dependency.exportjar.targetPath": "The default output path of export jar"
+  "configuration.java.project.exportjar.targetPath": "The default output path of export jar"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -22,5 +22,6 @@
   "configuration.java.dependency.syncWithFolderExplorer": "在 Java 项目管理器中同步关联当前打开的文件",
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",
   "configuration.java.dependency.refreshDelay": "控制 Java 项目管理器刷新的延迟时间 (毫秒)",
-  "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示"
+  "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示",
+  "configuration.java.dependency.exportjar.defaultTargetPath": "导出 Jar 文件的默认路径"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",
   "configuration.java.dependency.refreshDelay": "控制 Java 项目管理器刷新的延迟时间 (毫秒)",
   "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示",
-  "configuration.java.dependency.exportjar.defaultTargetPath": "导出 Jar 文件的默认路径"
+  "configuration.java.dependency.exportjar.targetPath": "导出 Jar 文件的默认路径"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",
   "configuration.java.dependency.refreshDelay": "控制 Java 项目管理器刷新的延迟时间 (毫秒)",
   "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示",
-  "configuration.java.project.exportjar.targetPath": "导出 Jar 文件的默认路径"
+  "configuration.java.project.exportJar.targetPath": "导出 Jar 文件的默认路径"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -23,5 +23,5 @@
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",
   "configuration.java.dependency.refreshDelay": "控制 Java 项目管理器刷新的延迟时间 (毫秒)",
   "configuration.java.dependency.packagePresentation": "Java 包显示方式: 平行显示或者分层显示",
-  "configuration.java.dependency.exportjar.targetPath": "导出 Jar 文件的默认路径"
+  "configuration.java.project.exportjar.targetPath": "导出 Jar 文件的默认路径"
 }

--- a/src/exportJarFileCommand.ts
+++ b/src/exportJarFileCommand.ts
@@ -28,7 +28,7 @@ const stepMap: Map<ExportJarStep, IExportJarStepExecutor> = new Map<ExportJarSte
 
 let isExportingJar: boolean = false;
 
-export async function createJarFileEntry(node?: INodeData): Promise<void> {
+export async function executeExportJarTask(node?: INodeData): Promise<void> {
     if (!isStandardServerReady() || isExportingJar || await buildWorkspace() === false) {
         return;
     }

--- a/src/exportJarFileCommand.ts
+++ b/src/exportJarFileCommand.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { EOL, platform } from "os";
-import { commands, Uri, window } from "vscode";
-import { sendOperationError } from "vscode-extension-telemetry-wrapper";
+import { tasks } from "vscode";
 import { buildWorkspace } from "./build";
+import { ExportJarTaskProvider } from "./exportJarSteps/ExportJarTaskProvider";
 import { GenerateJarExecutor } from "./exportJarSteps/GenerateJarExecutor";
 import { IExportJarStepExecutor } from "./exportJarSteps/IExportJarStepExecutor";
 import { IStepMetadata } from "./exportJarSteps/IStepMetadata";
 import { ResolveJavaProjectExecutor } from "./exportJarSteps/ResolveJavaProjectExecutor";
 import { ResolveMainMethodExecutor } from "./exportJarSteps/ResolveMainMethodExecutor";
+import { ErrorWithHandler, failMessage, successMessage } from "./exportJarSteps/utility";
 import { isStandardServerReady } from "./extension";
 import { INodeData } from "./java/nodeData";
 
@@ -20,74 +20,69 @@ export enum ExportJarStep {
     Finish = "FINISH",
 }
 
-let isExportingJar: boolean = false;
 const stepMap: Map<ExportJarStep, IExportJarStepExecutor> = new Map<ExportJarStep, IExportJarStepExecutor>([
     [ExportJarStep.ResolveJavaProject, new ResolveJavaProjectExecutor()],
     [ExportJarStep.ResolveMainMethod, new ResolveMainMethodExecutor()],
     [ExportJarStep.GenerateJar, new GenerateJarExecutor()],
 ]);
 
-export async function createJarFile(node?: INodeData) {
-    if (!isStandardServerReady() || isExportingJar) {
+let isExportingJar: boolean = false;
+
+export async function createJarFileEntry(node?: INodeData): Promise<boolean> {
+    if (!isStandardServerReady() || await buildWorkspace() === false || isExportingJar) {
         return;
     }
     isExportingJar = true;
-    return new Promise<string>(async (resolve, reject) => {
-        if (await buildWorkspace() === false) {
-            return reject();
+    const step: ExportJarStep = ExportJarStep.ResolveJavaProject;
+    const stepMetadata: IStepMetadata = {
+        entry: node,
+        steps: [],
+    };
+    try {
+        await stepMap.get(step).execute(stepMetadata);
+    } catch (err) {
+        isExportingJar = false;
+        if (err) {
+            failMessage(`${err}`);
         }
-        let step: ExportJarStep = ExportJarStep.ResolveJavaProject;
-        let stepMetadata: IStepMetadata = {
-            entry: node,
-            elements: [],
-            steps: [],
-        };
+        return true;
+    }
+    tasks.executeTask(ExportJarTaskProvider.getTask(stepMetadata)); // async
+    return new Promise<boolean>((resolve, reject) => {
+        tasks.onDidEndTask((e) => {
+            if (e.execution.task.source === ExportJarTaskProvider.exportJarType) {
+                isExportingJar = false;
+                if (stepMetadata.workspaceFolder === undefined) {
+                    resolve(false);
+                } else {
+                    resolve(true);
+                }
+            }
+        });
+    });
+}
+
+export async function createJarFile(stepMetadata: IStepMetadata) {
+    let step: ExportJarStep = ExportJarStep.ResolveMainMethod;
+    return new Promise<string>(async (resolve, reject) => {
         while (step !== ExportJarStep.Finish) {
             try {
-                const executor: IExportJarStepExecutor = stepMap.get(step);
-                if (executor === undefined) {
-                    // Unpredictable error, return to the initialization
-                    step = ExportJarStep.ResolveJavaProject;
-                    stepMetadata = {
-                        entry: node,
-                        elements: [],
-                        steps: [],
-                    };
-                } else {
-                    step = await executor.execute(stepMetadata);
+                step = await stepMap.get(step).execute(stepMetadata);
+                if (step === ExportJarStep.ResolveJavaProject) {
+                    return reject();
                 }
             } catch (err) {
-                return err ? reject(`${err}`) : reject();
+                return reject(err);
             }
         }
         return resolve(stepMetadata.outputPath);
     }).then((message) => {
         successMessage(message);
-        isExportingJar = false;
     }, (err) => {
-        failMessage(err);
-        isExportingJar = false;
+        if (err instanceof ErrorWithHandler) {
+            failMessage(err.message, err.handler);
+        } else if (err) {
+            failMessage(`${err}`);
+        }
     });
-}
-
-function failMessage(message: string) {
-    sendOperationError("", "Export Jar", new Error(message));
-    window.showErrorMessage(message, "Done");
-}
-
-function successMessage(outputFileName: string) {
-    let openInExplorer: string;
-    if (platform() === "win32") {
-        openInExplorer = "Reveal in File Explorer";
-    } else if (platform() === "darwin") {
-        openInExplorer = "Reveal in Finder";
-    } else {
-        openInExplorer = "Open Containing Folder";
-    }
-    window.showInformationMessage("Successfully exported jar to" + EOL + outputFileName,
-        openInExplorer, "Done").then((messageResult) => {
-            if (messageResult === openInExplorer) {
-                commands.executeCommand("revealFileInOS", Uri.file(outputFileName));
-            }
-        });
 }

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -13,7 +13,7 @@ export class ExportJarTaskProvider implements TaskProvider {
     public static exportJarType: string = "exportjar";
 
     public static getTask(stepMetadata: IStepMetadata): Task {
-        const targetPathSetting: string = workspace.getConfiguration("java.dependency.exportjar").get<string>("defaultTargetFolder");
+        const targetPathSetting: string = workspace.getConfiguration("java.dependency.exportjar").get<string>("defaultTargetPath");
         const defaultDefinition: IExportJarTaskDefinition = {
             type: ExportJarTaskProvider.exportJarType,
             targetPath: targetPathSetting,

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider, TaskRevealKind, TerminalDimensions, workspace } from "vscode";
+import { createJarFile } from "../exportJarFileCommand";
+import { IStepMetadata } from "./IStepMetadata";
+
+export class ExportJarTaskProvider implements TaskProvider {
+
+    public static exportJarType: string = "exportjar";
+
+    public static getTask(stepMetadata: IStepMetadata): Task {
+        const targetPathSetting: string = workspace.getConfiguration("java.dependency.exportjar").get<string>("defaultTargetFolder");
+        const defaultDefinition: IExportJarTaskDefinition = {
+            type: ExportJarTaskProvider.exportJarType,
+            targetPath: targetPathSetting,
+            elements: [],
+            mainMethod: undefined,
+        };
+        const task: Task = new Task(defaultDefinition, stepMetadata.workspaceFolder, "DEFAULT_EXPORT", ExportJarTaskProvider.exportJarType,
+            new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> => {
+                return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
+            }));
+        task.presentationOptions.reveal = TaskRevealKind.Never;
+        return task;
+    }
+
+    public async resolveTask(_task: Task): Promise<Task> {
+        return _task;
+    }
+
+    public async provideTasks(): Promise<Task[]> {
+        return [];
+    }
+
+}
+
+class ExportJarTaskTerminal implements Pseudoterminal {
+
+    public writeEmitter = new EventEmitter<string>();
+    public closeEmitter = new EventEmitter<void>();
+
+    public onDidWrite: Event<string> = this.writeEmitter.event;
+    public onDidClose?: Event<void> = this.closeEmitter.event;
+    
+    private stepMetadata: IStepMetadata;
+
+    constructor(exportJarTaskDefinition: IExportJarTaskDefinition, stepMetadata: IStepMetadata) {
+        this.stepMetadata = stepMetadata;
+        this.stepMetadata.mainMethod = exportJarTaskDefinition.mainMethod;
+        this.stepMetadata.outputPath = exportJarTaskDefinition.targetPath;
+        this.stepMetadata.elements = exportJarTaskDefinition.elements;
+    }
+    
+    public async open(initialDimensions: TerminalDimensions | undefined): Promise<void> {
+        await createJarFile(this.stepMetadata);
+        this.closeEmitter.fire();
+    }
+
+    public close(): void {
+
+    }
+}
+
+interface IExportJarTaskDefinition extends TaskDefinition {
+    elements?: string[];
+    mainMethod?: string;
+    targetPath?: string;
+}

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT license.
 
 import {
-    CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider,
-    TaskRevealKind, TaskScope, TerminalDimensions, workspace,
+    CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition,
+    TaskProvider, TaskRevealKind, TaskScope, TerminalDimensions,
 } from "vscode";
 import { createJarFile } from "../exportJarFileCommand";
+import { getExportJarTargetPath } from "../settings";
 import { IStepMetadata } from "./IStepMetadata";
 
 export class ExportJarTaskProvider implements TaskProvider {
@@ -13,7 +14,7 @@ export class ExportJarTaskProvider implements TaskProvider {
     public static exportJarType: string = "exportjar";
 
     public static getTask(stepMetadata: IStepMetadata): Task {
-        const targetPathSetting: string = workspace.getConfiguration("java.dependency.exportjar").get<string>("defaultTargetPath");
+        const targetPathSetting: string = getExportJarTargetPath();
         const defaultDefinition: IExportJarTaskDefinition = {
             type: ExportJarTaskProvider.exportJarType,
             targetPath: targetPathSetting,

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -11,7 +11,7 @@ import { IStepMetadata } from "./IStepMetadata";
 
 export class ExportJarTaskProvider implements TaskProvider {
 
-    public static exportJarType: string = "exportjar";
+    public static exportJarType: string = "java";
 
     public static getTask(stepMetadata: IStepMetadata): Task {
         const targetPathSetting: string = Settings.getExportJarTargetPath();
@@ -21,7 +21,7 @@ export class ExportJarTaskProvider implements TaskProvider {
             elements: [],
             mainMethod: undefined,
         };
-        const task: Task = new Task(defaultDefinition, TaskScope.Workspace, "exportJarTask", ExportJarTaskProvider.exportJarType,
+        const task: Task = new Task(defaultDefinition, TaskScope.Workspace, "exportjar:default", ExportJarTaskProvider.exportJarType,
             new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> => {
                 return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
             }));

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -3,7 +3,7 @@
 
 import {
     CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider,
-    TaskRevealKind, TerminalDimensions, workspace,
+    TaskRevealKind, TaskScope, TerminalDimensions, workspace,
 } from "vscode";
 import { createJarFile } from "../exportJarFileCommand";
 import { IStepMetadata } from "./IStepMetadata";
@@ -20,7 +20,7 @@ export class ExportJarTaskProvider implements TaskProvider {
             elements: [],
             mainMethod: undefined,
         };
-        const task: Task = new Task(defaultDefinition, stepMetadata.workspaceFolder, "DEFAULT_EXPORT", ExportJarTaskProvider.exportJarType,
+        const task: Task = new Task(defaultDefinition, TaskScope.Workspace, "DEFAULT_EXPORT", ExportJarTaskProvider.exportJarType,
             new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> => {
                 return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
             }));

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -3,7 +3,7 @@
 
 import {
     CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider,
-    TaskRevealKind, TerminalDimensions, workspace
+    TaskRevealKind, TerminalDimensions, workspace,
 } from "vscode";
 import { createJarFile } from "../exportJarFileCommand";
 import { IStepMetadata } from "./IStepMetadata";

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider, TaskRevealKind, TerminalDimensions, workspace } from "vscode";
+import {
+    CustomExecution, Event, EventEmitter, Pseudoterminal, Task, TaskDefinition, TaskProvider,
+    TaskRevealKind, TerminalDimensions, workspace
+} from "vscode";
 import { createJarFile } from "../exportJarFileCommand";
 import { IStepMetadata } from "./IStepMetadata";
 
@@ -42,7 +45,7 @@ class ExportJarTaskTerminal implements Pseudoterminal {
 
     public onDidWrite: Event<string> = this.writeEmitter.event;
     public onDidClose?: Event<void> = this.closeEmitter.event;
-    
+
     private stepMetadata: IStepMetadata;
 
     constructor(exportJarTaskDefinition: IExportJarTaskDefinition, stepMetadata: IStepMetadata) {
@@ -51,7 +54,7 @@ class ExportJarTaskTerminal implements Pseudoterminal {
         this.stepMetadata.outputPath = exportJarTaskDefinition.targetPath;
         this.stepMetadata.elements = exportJarTaskDefinition.elements;
     }
-    
+
     public async open(initialDimensions: TerminalDimensions | undefined): Promise<void> {
         await createJarFile(this.stepMetadata);
         this.closeEmitter.fire();

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -6,7 +6,7 @@ import {
     TaskProvider, TaskRevealKind, TaskScope, TerminalDimensions,
 } from "vscode";
 import { createJarFile } from "../exportJarFileCommand";
-import { getExportJarTargetPath } from "../settings";
+import { Settings } from "../settings";
 import { IStepMetadata } from "./IStepMetadata";
 
 export class ExportJarTaskProvider implements TaskProvider {
@@ -14,14 +14,14 @@ export class ExportJarTaskProvider implements TaskProvider {
     public static exportJarType: string = "exportjar";
 
     public static getTask(stepMetadata: IStepMetadata): Task {
-        const targetPathSetting: string = getExportJarTargetPath();
+        const targetPathSetting: string = Settings.getExportJarTargetPath();
         const defaultDefinition: IExportJarTaskDefinition = {
             type: ExportJarTaskProvider.exportJarType,
             targetPath: targetPathSetting,
             elements: [],
             mainMethod: undefined,
         };
-        const task: Task = new Task(defaultDefinition, TaskScope.Workspace, "DEFAULT_EXPORT", ExportJarTaskProvider.exportJarType,
+        const task: Task = new Task(defaultDefinition, TaskScope.Workspace, "exportJarTask", ExportJarTaskProvider.exportJarType,
             new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> => {
                 return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
             }));

--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -51,13 +51,15 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                     }
                     destPath = outputUri.fsPath;
                 } else {
-                    if (extname(stepMetadata.outputPath) !== ".jar") {
-                        return reject(new Error("inValid target file extension."));
-                    }
                     // Both the absolute path and the relative path (to workspace folder) are supported.
                     destPath = (isAbsolute(stepMetadata.outputPath)) ?
                             stepMetadata.outputPath :
                             join(stepMetadata.workspaceFolder.uri.fsPath, stepMetadata.outputPath);
+                    // Since both the specific target folder and the specific target file are supported,
+                    // we regard a path as a file if it ends with ".jar". Otherwise, it was regarded as a folder.
+                    if (extname(stepMetadata.outputPath) !== ".jar") {
+                        destPath = join(destPath, stepMetadata.workspaceFolder.name + ".jar");
+                    }
                     try {
                         await ensureDir(dirname(destPath));
                     } catch (e) {

--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -9,7 +9,7 @@ import { ExportJarStep } from "../exportJarFileCommand";
 import { Jdtls } from "../java/jdtls";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
-import { createPickBox, IMessageOption, resetStepMetadata, saveDialog, SETTING_ASKUSER } from "./utility";
+import { createPickBox, resetStepMetadata, saveDialog, SETTING_ASKUSER } from "./utility";
 
 export class GenerateJarExecutor implements IExportJarStepExecutor {
 
@@ -57,7 +57,7 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                     // Both the absolute path and the relative path (to workspace folder) are supported.
                     destPath = (isAbsolute(stepMetadata.outputPath)) ?
                             stepMetadata.outputPath :
-                            normalize(join(stepMetadata.workspaceFolder.uri.fsPath, stepMetadata.outputPath));
+                            join(stepMetadata.workspaceFolder.uri.fsPath, stepMetadata.outputPath);
                     try {
                         await ensureDir(dirname(destPath));
                     } catch (e) {

--- a/src/exportJarSteps/IStepMetadata.ts
+++ b/src/exportJarSteps/IStepMetadata.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Uri } from "vscode";
+import { WorkspaceFolder } from "vscode";
 import { ExportJarStep } from "../exportJarFileCommand";
 import { INodeData } from "../java/nodeData";
 
 export interface IStepMetadata {
     entry?: INodeData;
-    workspaceUri?: Uri;
+    workspaceFolder?: WorkspaceFolder;
     projectList?: INodeData[];
-    selectedMainMethod?: string;
+    mainMethod?: string;
     outputPath?: string;
-    elements: string[];
+    elements?: string[];
     steps: ExportJarStep[];
 }

--- a/src/exportJarSteps/ResolveJavaProjectExecutor.ts
+++ b/src/exportJarSteps/ResolveJavaProjectExecutor.ts
@@ -22,7 +22,7 @@ export class ResolveJavaProjectExecutor implements IExportJarStepExecutor {
         return this.getNextStep();
     }
 
-    private async assignStepMetadata(stepMetadata: IStepMetadata, uri: Uri): Promise<void> {
+    private async setWorkspaceFolder(stepMetadata: IStepMetadata, uri: Uri): Promise<void> {
         stepMetadata.projectList = await Jdtls.getProjects(uri.toString());
         const folders = workspace.workspaceFolders;
         for (const folder of folders) {
@@ -34,13 +34,13 @@ export class ResolveJavaProjectExecutor implements IExportJarStepExecutor {
 
     private async resolveJavaProject(stepMetadata: IStepMetadata): Promise<void> {
         if (stepMetadata.entry instanceof WorkspaceNode) {
-            await this.assignStepMetadata(stepMetadata, Uri.parse(stepMetadata.entry.uri));
+            await this.setWorkspaceFolder(stepMetadata, Uri.parse(stepMetadata.entry.uri));
             return;
         }
         const folders = workspace.workspaceFolders;
         // Guarded by workspaceFolderCount != 0 in package.json
         if (folders.length === 1) {
-            await this.assignStepMetadata(stepMetadata, folders[0].uri);
+            await this.setWorkspaceFolder(stepMetadata, folders[0].uri);
             return;
         }
         const pickItems: IJavaProjectQuickPickItem[] = [];

--- a/src/exportJarSteps/ResolveMainMethodExecutor.ts
+++ b/src/exportJarSteps/ResolveMainMethodExecutor.ts
@@ -6,7 +6,7 @@ import { ExportJarStep } from "../exportJarFileCommand";
 import { Jdtls } from "../java/jdtls";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
-import { cleanLastStepData, createPickBox } from "./utility";
+import { createPickBox, resetStepMetadata } from "./utility";
 
 export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
 
@@ -26,7 +26,7 @@ export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
             return this.getNextStep();
         }
         const lastStep: ExportJarStep = stepMetadata.steps.pop();
-        cleanLastStepData(lastStep, stepMetadata);
+        resetStepMetadata(lastStep, stepMetadata);
         return lastStep;
     }
 

--- a/src/exportJarSteps/ResolveMainMethodExecutor.ts
+++ b/src/exportJarSteps/ResolveMainMethodExecutor.ts
@@ -6,7 +6,7 @@ import { ExportJarStep } from "../exportJarFileCommand";
 import { Jdtls } from "../java/jdtls";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
-import { createPickBox } from "./utility";
+import { cleanLastStepData, createPickBox } from "./utility";
 
 export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
 
@@ -19,10 +19,15 @@ export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
     }
 
     public async execute(stepMetadata: IStepMetadata): Promise<ExportJarStep> {
+        if (stepMetadata.mainMethod !== undefined) {
+            return this.getNextStep();
+        }
         if (await this.resolveMainMethod(stepMetadata)) {
             return this.getNextStep();
         }
-        return stepMetadata.steps.pop();
+        const lastStep: ExportJarStep = stepMetadata.steps.pop();
+        cleanLastStepData(lastStep, stepMetadata);
+        return lastStep;
     }
 
     private async resolveMainMethod(stepMetadata: IStepMetadata): Promise<boolean> {
@@ -35,11 +40,11 @@ export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
                 token.onCancellationRequested(() => {
                     return reject();
                 });
-                resolve(await Jdtls.getMainMethod(stepMetadata.workspaceUri.toString()));
+                resolve(await Jdtls.getMainMethod(stepMetadata.workspaceFolder.uri.toString()));
             });
         });
         if (mainMethods === undefined || mainMethods.length === 0) {
-            stepMetadata.selectedMainMethod = "";
+            stepMetadata.mainMethod = "";
             return true;
         }
         const pickItems: QuickPickItem[] = [];
@@ -67,7 +72,7 @@ export class ResolveMainMethodExecutor implements IExportJarStepExecutor {
                         }
                     }),
                     pickBox.onDidAccept(() => {
-                        stepMetadata.selectedMainMethod = pickBox.selectedItems[0].description;
+                        stepMetadata.mainMethod = pickBox.selectedItems[0].description;
                         stepMetadata.steps.push(ExportJarStep.ResolveMainMethod);
                         return resolve(true);
                     }),

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -1,7 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { QuickInputButtons, QuickPick, QuickPickItem, Uri, window } from "vscode";
+import { EOL, platform } from "os";
+import { commands, QuickInputButtons, QuickPick, QuickPickItem, SaveDialogOptions, Uri, window } from "vscode";
+import { sendOperationError } from "vscode-extension-telemetry-wrapper";
+import { ExportJarStep } from "../exportJarFileCommand";
+import { IStepMetadata } from "./IStepMetadata";
+
+export const SETTING_ASKUSER: string = "askUser";
+
+export function cleanLastStepData(lastStep: ExportJarStep, stepMetadata: IStepMetadata): void {
+    if (lastStep === ExportJarStep.ResolveJavaProject) {
+        stepMetadata.workspaceFolder = undefined;
+        stepMetadata.projectList = undefined;
+    } else if (lastStep === ExportJarStep.ResolveMainMethod) {
+        stepMetadata.mainMethod = undefined;
+    }
+}
 
 export function createPickBox<T extends QuickPickItem>(title: string, placeholder: string, items: T[],
                                                        backBtnEnabled: boolean, canSelectMany: boolean = false): QuickPick<T> {
@@ -13,4 +28,62 @@ export function createPickBox<T extends QuickPickItem>(title: string, placeholde
     pickBox.ignoreFocusOut = true;
     pickBox.buttons = backBtnEnabled ? [(QuickInputButtons.Back)] : [];
     return pickBox;
+}
+
+export interface IMessageOption {
+    title: string;
+    command: string;
+    arguments?: any;
+}
+export class ErrorWithHandler extends Error {
+    public handler: IMessageOption;
+    constructor(message: string, handler: IMessageOption) {
+        super(message);
+        this.handler = handler;
+    }
+}
+
+export async function saveDialog(workSpaceUri: Uri, title: string): Promise<Uri> {
+    const options: SaveDialogOptions = {
+        saveLabel: title,
+        defaultUri: workSpaceUri,
+        filters: {
+            "Java Archive": ["jar"],
+        },
+    };
+    return Promise.resolve(await window.showSaveDialog(options));
+}
+
+export function failMessage(message: string, option?: IMessageOption) {
+    sendOperationError("", "Export Jar", new Error(message));
+    if (option === undefined) {
+        window.showErrorMessage(message, "Done");
+    } else {
+        window.showErrorMessage(message, option.title, "Done").then((result) => {
+            if (result === option.title) {
+                if (option.arguments === undefined) {
+                    commands.executeCommand(option.command);
+                } else {
+                    commands.executeCommand(option.command, ...option.arguments);
+                }
+            }
+        });
+    }
+}
+
+export function successMessage(outputFileName: string) {
+    let openInExplorer: string;
+    if (platform() === "win32") {
+        openInExplorer = "Reveal in File Explorer";
+    } else if (platform() === "darwin") {
+        openInExplorer = "Reveal in Finder";
+    } else {
+        openInExplorer = "Open Containing Folder";
+    }
+    window.showInformationMessage("Successfully exported jar to" + EOL + outputFileName,
+        openInExplorer, "Done").then((messageResult) => {
+            if (messageResult === openInExplorer) {
+                commands.executeCommand("revealFileInOS", Uri.file(outputFileName));
+            }
+        });
 }

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -35,13 +35,6 @@ export interface IMessageOption {
     command: string;
     arguments?: any;
 }
-export class ErrorWithHandler extends Error {
-    public handler: IMessageOption;
-    constructor(message: string, handler: IMessageOption) {
-        super(message);
-        this.handler = handler;
-    }
-}
 
 export async function saveDialog(workSpaceUri: Uri, title: string): Promise<Uri> {
     const options: SaveDialogOptions = {

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -9,11 +9,11 @@ import { IStepMetadata } from "./IStepMetadata";
 
 export const SETTING_ASKUSER: string = "askUser";
 
-export function cleanLastStepData(lastStep: ExportJarStep, stepMetadata: IStepMetadata): void {
-    if (lastStep === ExportJarStep.ResolveJavaProject) {
+export function resetStepMetadata(resetTo: ExportJarStep, stepMetadata: IStepMetadata): void {
+    if (resetTo === ExportJarStep.ResolveJavaProject) {
         stepMetadata.workspaceFolder = undefined;
         stepMetadata.projectList = undefined;
-    } else if (lastStep === ExportJarStep.ResolveMainMethod) {
+    } else if (resetTo === ExportJarStep.ResolveMainMethod) {
         stepMetadata.mainMethod = undefined;
     }
 }

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -13,6 +13,7 @@ export function resetStepMetadata(resetTo: ExportJarStep, stepMetadata: IStepMet
     if (resetTo === ExportJarStep.ResolveJavaProject) {
         stepMetadata.workspaceFolder = undefined;
         stepMetadata.projectList = undefined;
+        stepMetadata.mainMethod = undefined;
     } else if (resetTo === ExportJarStep.ResolveMainMethod) {
         stepMetadata.mainMethod = undefined;
     }

--- a/src/java/jdtls.ts
+++ b/src/java/jdtls.ts
@@ -3,6 +3,7 @@
 
 import { commands } from "vscode";
 import { Commands, executeJavaLanguageServerCommand } from "../commands";
+import { IExportResult } from "../exportJarSteps/GenerateJarExecutor";
 import { MainMethodInfo } from "../exportJarSteps/ResolveMainMethodExecutor";
 import { INodeData } from "./nodeData";
 
@@ -27,7 +28,7 @@ export namespace Jdtls {
         return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_GETMAINMETHOD, params);
     }
 
-    export function exportJar(mainMethod: string, elements: string[], destination: string): Thenable<boolean> {
+    export function exportJar(mainMethod: string, elements: string[], destination: string): Thenable<IExportResult> {
         return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_GENERATEJAR, mainMethod, elements, destination);
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -127,3 +127,7 @@ export interface IReferencedLibraries {
     exclude: string[];
     sources: { [binary: string]: string };
 }
+
+export function getExportJarTargetPath(): string {
+    return workspace.getConfiguration("java.dependency.exportjar").get<string>("targetPath");
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -110,6 +110,10 @@ export class Settings {
         return this._dependencyConfig.get("refreshDelay");
     }
 
+    public static getExportJarTargetPath(): string {
+        return workspace.getConfiguration("java.dependency.exportjar").get<string>("targetPath");
+    }
+
     private static _dependencyConfig: WorkspaceConfiguration = workspace.getConfiguration("java.dependency");
 
     private static _configurationListeners: Listener[] = [];
@@ -126,8 +130,4 @@ export interface IReferencedLibraries {
     include: string[];
     exclude: string[];
     sources: { [binary: string]: string };
-}
-
-export function getExportJarTargetPath(): string {
-    return workspace.getConfiguration("java.dependency.exportjar").get<string>("targetPath");
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -112,7 +112,7 @@ export class Settings {
 
     public static getExportJarTargetPath(): string {
         // tslint:disable-next-line: no-invalid-template-strings
-        return workspace.getConfiguration("java.project.exportjar").get<string>("targetPath", "${workspaceFolder}/${workspaceFolderBasename}.jar");
+        return workspace.getConfiguration("java.project.exportJar").get<string>("targetPath", "${workspaceFolder}/${workspaceFolderBasename}.jar");
     }
 
     private static _dependencyConfig: WorkspaceConfiguration = workspace.getConfiguration("java.dependency");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,7 +111,8 @@ export class Settings {
     }
 
     public static getExportJarTargetPath(): string {
-        return workspace.getConfiguration("java.dependency.exportjar").get<string>("targetPath");
+        // tslint:disable-next-line: no-invalid-template-strings
+        return workspace.getConfiguration("java.project.exportjar").get<string>("targetPath", "${workspaceFolder}/${workspaceFolderBasename}.jar");
     }
 
     private static _dependencyConfig: WorkspaceConfiguration = workspace.getConfiguration("java.dependency");

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -37,7 +37,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
-            while (await createJarFileEntry(node) === false) {}
+            createJarFileEntry(node);
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, (node: DataNode) => newJavaClass(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_PACKAGE, (node: DataNode) => newPackage(node)));
@@ -48,9 +48,9 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node: INodeData) =>
             commands.executeCommand("copyRelativeFilePath", Uri.parse(node.uri))));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OPEN_FILE, (uri) =>
-                commands.executeCommand(Commands.VSCODE_OPEN, Uri.parse(uri))));
+            commands.executeCommand(Commands.VSCODE_OPEN, Uri.parse(uri))));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OUTLINE, (uri, range) =>
-                window.showTextDocument(Uri.parse(uri), { selection: range })));
+            window.showTextDocument(Uri.parse(uri), { selection: range })));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_BUILD_WORKSPACE, () =>
             commands.executeCommand(Commands.JAVA_BUILD_WORKSPACE)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CLEAN_WORKSPACE, () =>

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -9,7 +9,7 @@ import {
 import { instrumentOperation, instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
 import { newJavaClass, newPackage } from "../explorerCommands/new";
-import { createJarFile } from "../exportJarFileCommand";
+import { createJarFile, createJarFileEntry } from "../exportJarFileCommand";
 import { isLightWeightMode, isSwitchingServer } from "../extension";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
@@ -36,7 +36,9 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
     constructor(public readonly context: ExtensionContext) {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
-        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, (node: INodeData) => createJarFile(node)));
+        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
+            while (await createJarFileEntry(node) === false) {}
+        }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, (node: DataNode) => newJavaClass(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_PACKAGE, (node: DataNode) => newPackage(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_FILE_OS, (node?: INodeData) =>

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -9,7 +9,7 @@ import {
 import { instrumentOperation, instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
 import { newJavaClass, newPackage } from "../explorerCommands/new";
-import { createJarFile, createJarFileEntry } from "../exportJarFileCommand";
+import { executeExportJarTask } from "../exportJarFileCommand";
 import { isLightWeightMode, isSwitchingServer } from "../extension";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
@@ -37,7 +37,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
-            createJarFileEntry(node);
+            executeExportJarTask(node);
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, (node: DataNode) => newJavaClass(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_PACKAGE, (node: DataNode) => newPackage(node)));


### PR DESCRIPTION
fix #330 
This PR includes following things:
1. Use `vscode.task` to refactor export process to make it is possible to parse VS Code variables like `${workspaceFolder}`.
2. Offer a setting named `defaultTargetFolder`, which can change the default target path of export jar by opening a dialog.
3. Some enhancement in `jdtls.ext`, such as error reporting and variables renaming
4. Some changes in `IStepMetadata` to make it sense.