### PR TITLE
fix: Validate input & change pre-fill value

### DIFF
--- a/src/explorerCommands/new.ts
+++ b/src/explorerCommands/new.ts
@@ -138,7 +138,7 @@ function getNewPackagePath(packageRootPath: string, packageName: string): string
     return path.join(packageRootPath, ...packageName.split("."));
 }
 
-function checkJavaQualifiedName(value: string): string {
+export function checkJavaQualifiedName(value: string): string {
     if (!value || !value.trim()) {
         return "Input cannot be empty.";
     }

--- a/src/explorerCommands/new.ts
+++ b/src/explorerCommands/new.ts
@@ -5,8 +5,8 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import { QuickPickItem, Uri, window, workspace, WorkspaceEdit } from "vscode";
 import { NodeKind } from "../java/nodeData";
-import { isJavaIdentifier, isKeyword } from "../utility";
 import { DataNode } from "../views/dataNode";
+import { checkJavaQualifiedName } from "./utils";
 
 export async function newJavaClass(node: DataNode): Promise<void> {
     const packageFsPath: string = await getPackageFsPath(node);
@@ -136,24 +136,6 @@ function getPackageRootPath(packageFsPath: string, packageName: string): string 
 
 function getNewPackagePath(packageRootPath: string, packageName: string): string {
     return path.join(packageRootPath, ...packageName.split("."));
-}
-
-export function checkJavaQualifiedName(value: string): string {
-    if (!value || !value.trim()) {
-        return "Input cannot be empty.";
-    }
-
-    for (const part of value.split(".")) {
-        if (isKeyword(part)) {
-            return `Keyword '${part}' cannot be used.`;
-        }
-
-        if (!isJavaIdentifier(part)) {
-            return `Invalid Java qualified name.`;
-        }
-    }
-
-    return "";
 }
 
 interface ISourceRootPickItem extends QuickPickItem {

--- a/src/explorerCommands/rename.ts
+++ b/src/explorerCommands/rename.ts
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as fse from "fs-extra";
 import * as path from "path";
 import { Uri, window, workspace, WorkspaceEdit } from "vscode";
+import { NodeKind } from "../java/nodeData";
 import { DataNode } from "../views/dataNode";
 import { ExplorerNode } from "../views/explorerNode";
+import { checkJavaQualifiedName } from "./new";
 import { isMutable } from "./utils";
 
 export async function renameFile(node: DataNode, selectedNode: ExplorerNode): Promise<void> {
@@ -16,29 +19,85 @@ export async function renameFile(node: DataNode, selectedNode: ExplorerNode): Pr
         }
     }
 
+    const oldFsPath = Uri.parse(node.uri).fsPath;
+
     const newName: string | undefined = await window.showInputBox({
         placeHolder: "Input new file name",
-        value: node.name,
+        value: getPrefillValue(node),
         ignoreFocusOut: true,
+        valueSelection: getValueSelection(node.uri),
+        validateInput: async (value: string): Promise<string> => {
+            const checkMessage = CheckQualifiedInputName(value, node.nodeData.kind);
+            if (checkMessage) {
+                return checkMessage;
+            }
+
+            if (await fse.pathExists(getRenamedFsPath(oldFsPath, value))) {
+                return "Class/Package already exists.";
+            }
+
+            return "";
+        },
     });
 
     if (!newName) {
         return;
     }
 
-    const oldFsPath = Uri.parse(node.uri).fsPath;
-    const renamedFilePath = getRenamedFilePath(oldFsPath, newName);
-
+    const newFsPath = getRenamedFsPath(oldFsPath, newName);
     const workspaceEdit: WorkspaceEdit = new WorkspaceEdit();
-    workspaceEdit.renameFile(Uri.file(oldFsPath), Uri.file(renamedFilePath));
+    workspaceEdit.renameFile(Uri.file(oldFsPath), Uri.file(newFsPath));
     workspace.applyEdit(workspaceEdit);
 }
 
-function getRenamedFilePath(oldUri: string, newName: string): string {
+function getRenamedFsPath(oldUri: string, newName: string): string {
     // preserve default file extension if not provided
     if (!path.extname(newName)) {
         newName += path.extname(oldUri);
     }
     const dirname = path.dirname(oldUri);
     return path.join(dirname, newName);
+}
+
+function getPrefillValue(node: DataNode): string {
+    const nodeKind = node.nodeData.kind;
+    if (nodeKind === NodeKind.PrimaryType) {
+        return node.name;
+    }
+    return path.basename(node.uri);
+}
+
+function getValueSelection(uri: string): [number, number] | undefined {
+    const pos = path.basename(uri).lastIndexOf(".");
+    if (pos !== -1) {
+        return [0, pos];
+    }
+    return undefined;
+}
+
+function CheckQualifiedInputName(value: string, nodeKind: NodeKind): string {
+    const capitalStartExp = /[A-Z](.*?)/;
+    const lowerOnlyExp = /(?=.*[A-Z])/;
+    const javaValidateMessage = checkJavaQualifiedName(value);
+
+    if (javaValidateMessage) {
+        return javaValidateMessage;
+    }
+
+    if (nodeKind === NodeKind.PrimaryType) {
+        if (!capitalStartExp.test(value)) {
+            return "Class name should start with upper case.";
+        }
+    }
+
+    if (nodeKind === NodeKind.Package || nodeKind === NodeKind.PackageRoot) {
+        if (lowerOnlyExp.test(value)) {
+            return "Package name should be lower case only.";
+        }
+        if (value.indexOf(".") !== -1) {
+            return "Cross-level rename is not supportted.";
+        }
+    }
+
+    return "";
 }

--- a/src/explorerCommands/utils.ts
+++ b/src/explorerCommands/utils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { isJavaIdentifier, isKeyword } from "../utility";
 import { DataNode } from "../views/dataNode";
 
 export function isMutable(node: DataNode): boolean {
@@ -10,4 +11,22 @@ export function isMutable(node: DataNode): boolean {
 
     const contextValue = node.computeContextValue();
     return packageExp.test(contextValue) || resourceOrTypeExp.test(contextValue);
+}
+
+export function checkJavaQualifiedName(value: string): string {
+    if (!value || !value.trim()) {
+        return "Input cannot be empty.";
+    }
+
+    for (const part of value.split(".")) {
+        if (isKeyword(part)) {
+            return `Keyword '${part}' cannot be used.`;
+        }
+
+        if (!isJavaIdentifier(part)) {
+            return `Invalid Java qualified name.`;
+        }
+    }
+
+    return "";
 }


### PR DESCRIPTION
This PR fixed two parts:

1. Input validation:
- If user rename `PrimaryTypeNode`, then:
    1) Input should be a legal Java identifier 
- If user rename `packageRoot` or `packageRootNode`, then:
    1) Input should also be a legal identifier
    3) Could not contain `.`, due to limitations, currently we can only rename innermost package

2. Pre-fill value:
- For package, since cross-level rename is not supported, we only show innermost folder name
- For `PrimaryTypeNode`, only show class name
- For other files, show extension name, but not pre-selected
