### PR TITLE
feat: Add more keybindings for context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,27 @@
     },
     "keybindings": [
       {
+        "command": "java.view.package.revealFileInOS",
+        "key": "ctrl+alt+r",
+        "win": "shift+alt+r",
+        "mac": "cmd+alt+r",
+        "when": "java:projectManagerActivated && focusedView == javaProjectExplorer"
+      },
+      {
+        "command": "java.view.package.copyFilePath",
+        "key": "ctrl+alt+c",
+        "win": "shift+alt+c",
+        "mac": "cmd+alt+c",
+        "when": "java:projectManagerActivated && focusedView == javaProjectExplorer"
+      },
+      {
+        "command": "java.view.package.copyRelativeFilePath",
+        "key": "ctrl+shift+alt+c",
+        "win": "ctrl+k ctrl+shift+c",
+        "mac": "cmd+shift+alt+c",
+        "when": "java:projectManagerActivated && focusedView == javaProjectExplorer"
+      },
+      {
         "command": "java.view.package.renameFile",
         "key": "F2",
         "mac": "enter",

--- a/src/explorerCommands/delete.ts
+++ b/src/explorerCommands/delete.ts
@@ -3,10 +3,15 @@
 
 import { Uri, window, workspace } from "vscode";
 import { DataNode } from "../views/dataNode";
+import { isMutable } from "./utility";
 
 const confirmMessage = "Move to Recycle Bin";
 
 export async function deleteFiles(node: DataNode): Promise<void> {
+    if (!isMutable(node) || !node.uri) {
+        return;
+    }
+
     const children = await node.getChildren();
     const isFolder = children && children.length !== 0;
     const message = getInformationMessage(node.name, isFolder);

--- a/src/explorerCommands/delete.ts
+++ b/src/explorerCommands/delete.ts
@@ -3,20 +3,10 @@
 
 import { Uri, window, workspace } from "vscode";
 import { DataNode } from "../views/dataNode";
-import { ExplorerNode } from "../views/explorerNode";
-import { isMutable } from "./utility";
 
 const confirmMessage = "Move to Recycle Bin";
 
-export async function deleteFiles(node: DataNode, selectedNode: ExplorerNode): Promise<void> {
-    // if command not invoked by context menu, use selected node in explorer
-    if (!node) {
-        node = selectedNode as DataNode;
-        if (!isMutable(node)) {
-            return;
-        }
-    }
-
+export async function deleteFiles(node: DataNode): Promise<void> {
     const children = await node.getChildren();
     const isFolder = children && children.length !== 0;
     const message = getInformationMessage(node.name, isFolder);

--- a/src/explorerCommands/rename.ts
+++ b/src/explorerCommands/rename.ts
@@ -6,18 +6,9 @@ import * as path from "path";
 import { Uri, window, workspace, WorkspaceEdit } from "vscode";
 import { NodeKind } from "../java/nodeData";
 import { DataNode } from "../views/dataNode";
-import { ExplorerNode } from "../views/explorerNode";
-import { checkJavaQualifiedName, isMutable } from "./utility";
+import { checkJavaQualifiedName } from "./utility";
 
-export async function renameFile(node: DataNode, selectedNode: ExplorerNode): Promise<void> {
-    // if command not invoked by context menu, use selected node in explorer
-    if (!node) {
-        node = selectedNode as DataNode;
-        if (!isMutable(node)) {
-            return;
-        }
-    }
-
+export async function renameFile(node: DataNode): Promise<void> {
     const oldFsPath = Uri.parse(node.uri).fsPath;
 
     const newName: string | undefined = await window.showInputBox({

--- a/src/explorerCommands/rename.ts
+++ b/src/explorerCommands/rename.ts
@@ -6,9 +6,13 @@ import * as path from "path";
 import { Uri, window, workspace, WorkspaceEdit } from "vscode";
 import { NodeKind } from "../java/nodeData";
 import { DataNode } from "../views/dataNode";
-import { checkJavaQualifiedName } from "./utility";
+import { checkJavaQualifiedName, isMutable } from "./utility";
 
 export async function renameFile(node: DataNode): Promise<void> {
+    if (!isMutable(node) || !node.uri) {
+        return;
+    }
+
     const oldFsPath = Uri.parse(node.uri).fsPath;
 
     const newName: string | undefined = await window.showInputBox({
@@ -55,7 +59,7 @@ function getPrefillValue(node: DataNode): string {
     if (nodeKind === NodeKind.PrimaryType) {
         return node.name;
     }
-    return path.basename(node.uri);
+    return path.basename(node.uri!);
 }
 
 function getValueSelection(uri: string): [number, number] | undefined {

--- a/src/explorerCommands/utility.ts
+++ b/src/explorerCommands/utility.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { commands, Uri } from "vscode";
 import { isJavaIdentifier, isKeyword } from "../utility";
 import { DataNode } from "../views/dataNode";
 import { ExplorerNode } from "../views/explorerNode";
@@ -33,24 +32,7 @@ export function checkJavaQualifiedName(value: string): string {
     return "";
 }
 
-export function getVSCodeCmdHandler(command: string) {
-    return async (node: DataNode) => {
-        if (node.uri) {
-            commands.executeCommand(command, Uri.parse(node.uri));
-        }
-    };
-}
-
-export function handleKeyBindingCmd(node: DataNode, selectedNode: ExplorerNode,
-                                    handler: (node: DataNode) => Promise<void>,
-                                    mutableCheck: boolean = false) {
+export function getCmdNode(selectedNode: ExplorerNode, node?: DataNode): DataNode {
     // if command not invoked by context menu, use selected node in explorer
-    if (!node) {
-        node = selectedNode as DataNode;
-        if (mutableCheck && !isMutable(node)) {
-            return;
-        }
-    }
-
-    handler(node);
+    return node ? node : selectedNode as DataNode;
 }

--- a/src/explorerCommands/utility.ts
+++ b/src/explorerCommands/utility.ts
@@ -42,11 +42,12 @@ export function getVSCodeCmdHandler(command: string) {
 }
 
 export function handleKeyBindingCmd(node: DataNode, selectedNode: ExplorerNode,
-                                    handler: (node: DataNode) => Promise<void>) {
+                                    handler: (node: DataNode) => Promise<void>,
+                                    mutableCheck: boolean = false) {
     // if command not invoked by context menu, use selected node in explorer
     if (!node) {
         node = selectedNode as DataNode;
-        if (!isMutable(node)) {
+        if (mutableCheck && !isMutable(node)) {
             return;
         }
     }

--- a/src/explorerCommands/utility.ts
+++ b/src/explorerCommands/utility.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { commands, Uri } from "vscode";
 import { isJavaIdentifier, isKeyword } from "../utility";
 import { DataNode } from "../views/dataNode";
+import { ExplorerNode } from "../views/explorerNode";
 
 export function isMutable(node: DataNode): boolean {
     // avoid modify dependency files
@@ -29,4 +31,25 @@ export function checkJavaQualifiedName(value: string): string {
     }
 
     return "";
+}
+
+export function getVSCodeCmdHandler(command: string) {
+    return async (node: DataNode) => {
+        if (node.uri) {
+            commands.executeCommand(command, Uri.parse(node.uri));
+        }
+    };
+}
+
+export function handleKeyBindingCmd(node: DataNode, selectedNode: ExplorerNode,
+                                    handler: (node: DataNode) => Promise<void>) {
+    // if command not invoked by context menu, use selected node in explorer
+    if (!node) {
+        node = selectedNode as DataNode;
+        if (!isMutable(node)) {
+            return;
+        }
+    }
+
+    handler(node);
 }

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -41,12 +41,6 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, (node: DataNode) => newJavaClass(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_PACKAGE, (node: DataNode) => newPackage(node)));
-        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_FILE_OS, (node?: INodeData) =>
-            commands.executeCommand("revealFileInOS", Uri.parse(node.uri))));
-        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_FILE_PATH, (node: INodeData) =>
-            commands.executeCommand("copyFilePath", Uri.parse(node.uri))));
-        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node: INodeData) =>
-            commands.executeCommand("copyRelativeFilePath", Uri.parse(node.uri))));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OPEN_FILE, (uri) =>
             commands.executeCommand(Commands.VSCODE_OPEN, Uri.parse(uri), { preserveFocus: true })));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OUTLINE, (uri, range) =>

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -9,6 +9,7 @@ import { Commands } from "../commands";
 import { Build } from "../constants";
 import { deleteFiles } from "../explorerCommands/delete";
 import { renameFile } from "../explorerCommands/rename";
+import { getVSCodeCmdHandler, handleKeyBindingCmd } from "../explorerCommands/utility";
 import { isStandardServerReady } from "../extension";
 import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
@@ -84,15 +85,34 @@ export class DependencyExplorer implements Disposable {
             }),
         );
 
+        // register keybinding commands
+        context.subscriptions.push(
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_FILE_OS, (node: DataNode) => {
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("revealFileInOS"));
+            }),
+        );
+
+        context.subscriptions.push(
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_FILE_PATH, (node: DataNode) => {
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("copyFilePath"));
+            }),
+        );
+
+        context.subscriptions.push(
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node: DataNode) => {
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("copyRelativeFilePath"));
+            }),
+        );
+
         context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_RENAME_FILE, (node: DataNode) => {
-                renameFile(node, this._dependencyViewer.selection[0]);
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], renameFile);
             }),
         );
 
         context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node: DataNode) => {
-                deleteFiles(node, this._dependencyViewer.selection[0]);
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], deleteFiles);
             }),
         );
     }

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -9,7 +9,7 @@ import { Commands } from "../commands";
 import { Build } from "../constants";
 import { deleteFiles } from "../explorerCommands/delete";
 import { renameFile } from "../explorerCommands/rename";
-import { getVSCodeCmdHandler, handleKeyBindingCmd } from "../explorerCommands/utility";
+import { getCmdNode } from "../explorerCommands/utility";
 import { isStandardServerReady } from "../extension";
 import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
@@ -87,32 +87,41 @@ export class DependencyExplorer implements Disposable {
 
         // register keybinding commands
         context.subscriptions.push(
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_FILE_OS, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("revealFileInOS"));
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_FILE_OS, (node?: DataNode) => {
+                const cmdNode = getCmdNode(this._dependencyViewer.selection[0], node);
+                if (cmdNode.uri) {
+                    commands.executeCommand("revealFileInOS", Uri.parse(cmdNode.uri));
+                }
             }),
         );
 
         context.subscriptions.push(
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_FILE_PATH, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("copyFilePath"));
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_FILE_PATH, (node?: DataNode) => {
+                const cmdNode = getCmdNode(this._dependencyViewer.selection[0], node);
+                if (cmdNode.uri) {
+                    commands.executeCommand("copyFilePath", Uri.parse(cmdNode.uri));
+                }
             }),
         );
 
         context.subscriptions.push(
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], getVSCodeCmdHandler("copyRelativeFilePath"));
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node?: DataNode) => {
+                const cmdNode = getCmdNode(this._dependencyViewer.selection[0], node);
+                if (cmdNode.uri) {
+                    commands.executeCommand("copyRelativeFilePath", Uri.parse(cmdNode.uri));
+                }
             }),
         );
 
         context.subscriptions.push(
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_RENAME_FILE, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], renameFile, true);
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_RENAME_FILE, (node?: DataNode) => {
+                renameFile(getCmdNode(this._dependencyViewer.selection[0], node));
             }),
         );
 
         context.subscriptions.push(
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], deleteFiles, true);
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node?: DataNode) => {
+                deleteFiles(getCmdNode(this._dependencyViewer.selection[0], node));
             }),
         );
     }

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -106,13 +106,13 @@ export class DependencyExplorer implements Disposable {
 
         context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_RENAME_FILE, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], renameFile);
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], renameFile, true);
             }),
         );
 
         context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node: DataNode) => {
-                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], deleteFiles);
+                handleKeyBindingCmd(node, this._dependencyViewer.selection[0], deleteFiles, true);
             }),
         );
     }


### PR DESCRIPTION
Add keybindings for `Reveal in Explorer`, `Copy Path`, `Copy Relative Path`.

![image](https://user-images.githubusercontent.com/30518415/100422121-a4b54b00-30c4-11eb-8b7d-55087dac644a.png)
![image](https://user-images.githubusercontent.com/30518415/100422992-3ec9c300-30c6-11eb-81d3-acfdb26dd6b2.png)

