### PR TITLE
refactor: Error reporting and null check in export jar

### DIFF
--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -212,14 +212,12 @@ class ExportJarTaskTerminal implements Pseudoterminal {
         let step: ExportJarStep = ExportJarStep.ResolveJavaProject;
         let previousStep: ExportJarStep | undefined;
         let executor: IExportJarStepExecutor | undefined;
-        let result: boolean;
         while (step !== ExportJarStep.Finish) {
             executor = stepMap.get(step);
             if (!executor) {
                 throw new Error(ExportJarMessages.stepErrorMessage(ExportJarMessages.StepAction.FINDEXECUTOR, step));
             }
-            result = await executor.execute(stepMetadata);
-            if (!result) {
+            if (!await executor.execute(stepMetadata)) {
                 // Go back
                 previousStep = stepMetadata.steps.pop();
                 if (!previousStep) {

--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -25,7 +25,6 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
         if (_.isEmpty(stepMetadata.elements)) {
             // If the user uses wizard or custom task with a empty list of elements,
             // the classpaths should be specified manually.
-            stepMetadata.classpaths = [];
             if (!(await this.generateClasspaths(stepMetadata))) {
                 return false;
             }
@@ -74,9 +73,9 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                 if (mainClass === undefined) {
                     return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.MAINCLASS, this.currentStep)));
                 }
-                const classpaths: IClasspath[] | undefined = stepMetadata.classpaths;
-                if (!classpaths || _.isEmpty(classpaths)) {
-                    return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.CLASSPATHS, this.currentStep)));
+                const classpaths: IClasspath[] = stepMetadata.classpaths;
+                if (_.isEmpty(classpaths)) {
+                    return reject(new Error(ExportJarMessages.CLASSPATHS_EMPTY));
                 }
                 const exportResult: IExportResult = await Jdtls.exportJar(basename(mainClass), classpaths, destPath);
                 if (exportResult.result === true) {
@@ -102,9 +101,9 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                 });
                 const pickItems: IJarQuickPickItem[] = [];
                 const uriSet: Set<string> = new Set<string>();
-                const projectList: INodeData[] | undefined = stepMetadata.projectList;
-                if (!projectList || _.isEmpty(projectList)) {
-                    return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.PROJECTLIST, this.currentStep)));
+                const projectList: INodeData[] = stepMetadata.projectList;
+                if (_.isEmpty(projectList)) {
+                    return reject(new Error(ExportJarMessages.WORKSPACE_EMPTY));
                 }
                 const workspaceFolder: WorkspaceFolder | undefined = stepMetadata.workspaceFolder;
                 if (!workspaceFolder) {
@@ -126,9 +125,6 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
         if (_.isEmpty(dependencyItems)) {
             throw new Error(ExportJarMessages.PROJECT_EMPTY);
         } else if (dependencyItems.length === 1) {
-            if (!stepMetadata.classpaths) {
-                return Promise.reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.CLASSPATHS, this.currentStep)));
-            }
             await this.setStepMetadataFromOutputFolder(dependencyItems[0].path, stepMetadata.classpaths);
             return true;
         }
@@ -163,9 +159,6 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
                     pickBox.onDidAccept(async () => {
                         if (_.isEmpty(pickBox.selectedItems)) {
                             return;
-                        }
-                        if (!stepMetadata.classpaths) {
-                            return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.CLASSPATHS, this.currentStep)));
                         }
                         for (const item of pickBox.selectedItems) {
                             if (item.type === "artifact") {

--- a/src/exportJarSteps/IExportJarStepExecutor.ts
+++ b/src/exportJarSteps/IExportJarStepExecutor.ts
@@ -2,10 +2,7 @@
 // Licensed under the MIT license.
 
 import { IStepMetadata } from "./IStepMetadata";
-import { ExportJarStep } from "./utility";
 
 export interface IExportJarStepExecutor {
-    getStep(): ExportJarStep;
-    getNextStep(): ExportJarStep;
-    execute(stepMetadata?: IStepMetadata): Promise<ExportJarStep>;
+    execute(stepMetadata?: IStepMetadata): Promise<boolean>;
 }

--- a/src/exportJarSteps/IExportJarStepExecutor.ts
+++ b/src/exportJarSteps/IExportJarStepExecutor.ts
@@ -5,6 +5,7 @@ import { IStepMetadata } from "./IStepMetadata";
 import { ExportJarStep } from "./utility";
 
 export interface IExportJarStepExecutor {
+    getStep(): ExportJarStep;
     getNextStep(): ExportJarStep;
     execute(stepMetadata?: IStepMetadata): Promise<ExportJarStep>;
 }

--- a/src/exportJarSteps/IStepMetadata.ts
+++ b/src/exportJarSteps/IStepMetadata.ts
@@ -8,11 +8,11 @@ import { ExportJarStep } from "./utility";
 export interface IStepMetadata {
     entry?: INodeData;
     workspaceFolder?: WorkspaceFolder;
-    projectList?: INodeData[];
     mainClass?: string;
-    elements?: string[];
-    classpaths?: IClasspath[];
     outputPath?: string;
+    projectList: INodeData[];
+    elements: string[];
+    classpaths: IClasspath[];
     steps: ExportJarStep[];
 }
 

--- a/src/exportJarSteps/ResolveJavaProjectExecutor.ts
+++ b/src/exportJarSteps/ResolveJavaProjectExecutor.ts
@@ -56,7 +56,7 @@ export class ResolveJavaProjectExecutor implements IExportJarStepExecutor {
             }
         }
         if (_.isEmpty(pickItems)) {
-            throw new Error(ExportJarMessages.JAVAPROJECTS_EMPTY);
+            throw new Error(ExportJarMessages.JAVAWORKSPACES_EMPTY);
         }
         const disposables: Disposable[] = [];
         try {
@@ -68,7 +68,11 @@ export class ResolveJavaProjectExecutor implements IExportJarStepExecutor {
                         if (_.isEmpty(pickBox.selectedItems)) {
                             return;
                         }
-                        stepMetadata.projectList = projectMap.get(pickBox.selectedItems[0].workspaceFolder.uri.toString());
+                        const projectList: INodeData[] = projectMap.get(pickBox.selectedItems[0].workspaceFolder.uri.toString()) || [];
+                        if (_.isEmpty(projectList)) {
+                            return reject(new Error(ExportJarMessages.WORKSPACE_EMPTY));
+                        }
+                        stepMetadata.projectList = projectList;
                         stepMetadata.workspaceFolder = pickBox.selectedItems[0].workspaceFolder;
                         stepMetadata.steps.push(ExportJarStep.ResolveJavaProject);
                         return resolve();

--- a/src/exportJarSteps/ResolveJavaProjectExecutor.ts
+++ b/src/exportJarSteps/ResolveJavaProjectExecutor.ts
@@ -12,27 +12,21 @@ import { createPickBox, ExportJarMessages, ExportJarStep } from "./utility";
 
 export class ResolveJavaProjectExecutor implements IExportJarStepExecutor {
 
-    public getStep(): ExportJarStep {
-        return ExportJarStep.ResolveJavaProject;
-    }
+    private readonly currentStep: ExportJarStep = ExportJarStep.ResolveJavaProject;
 
-    public getNextStep(): ExportJarStep {
-        return ExportJarStep.ResolveMainClass;
-    }
-
-    public async execute(stepMetadata: IStepMetadata): Promise<ExportJarStep> {
+    public async execute(stepMetadata: IStepMetadata): Promise<boolean> {
         if (stepMetadata.workspaceFolder === undefined) {
             await this.resolveJavaProject(stepMetadata);
         }
-        return this.getNextStep();
+        return true;
     }
 
     private async resolveJavaProject(stepMetadata: IStepMetadata): Promise<void> {
         // Guarded by workspaceFolderCount != 0 in package.json
         const folders = workspace.workspaceFolders!;
         if (stepMetadata.entry instanceof WorkspaceNode) {
-            if (!stepMetadata.entry || !stepMetadata.entry.uri) {
-                throw new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.ENTRY, this.getStep()));
+            if (!stepMetadata.entry?.uri) {
+                throw new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.ENTRY, this.currentStep));
             }
             const workspaceUri: Uri = Uri.parse(stepMetadata.entry.uri);
             for (const folder of folders) {

--- a/src/exportJarSteps/ResolveMainClassExecutor.ts
+++ b/src/exportJarSteps/ResolveMainClassExecutor.ts
@@ -39,7 +39,7 @@ export class ResolveMainClassExecutor implements IExportJarStepExecutor {
                 resolve(await Jdtls.getMainClasses(stepMetadata.workspaceFolder.uri.toString()));
             });
         });
-        if (mainClasses === undefined || mainClasses.length === 0) {
+        if (_.isEmpty(mainClasses)) {
             stepMetadata.mainClass = "";
             return true;
         }

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -53,12 +53,12 @@ export namespace ExportJarMessages {
         WORKSPACEFOLDER = "Workspace folder",
         OUTPUTPATH = "Target path",
         MAINCLASS = "Main class",
-        CLASSPATHS = "Elements",
-        PROJECTLIST = "Project list",
     }
 
-    export const JAVAPROJECTS_EMPTY = "No Java workspace found. Please make sure there is at least one valid Java workspace folder in your workspace folders.";
-    export const PROJECT_EMPTY = "No classpath found in the workspace. Please make sure your workspace contains valid Java project(s).";
+    export const JAVAWORKSPACES_EMPTY = "No Java workspace found. Please make sure there is at least one valid Java workspace folder in your workspace folders.";
+    export const WORKSPACE_EMPTY = "No Java project found in the workspace. Please make sure your workspace contains valid Java project(s).";
+    export const PROJECT_EMPTY = "No classpath found in the Java project. Please make sure your Java project is valid.";
+    export const CLASSPATHS_EMPTY = "No valid classpath found in the export jar configuration. Please make sure your configuration contains valid classpath(s).";
 
     export function fieldUndefinedMessage(field: Field, currentStep: ExportJarStep): string {
         return `The value of ${field} is invalid or has not been specified properly, current step: ${currentStep}. The export jar process will exit.`;
@@ -72,7 +72,7 @@ export namespace ExportJarMessages {
 export function resetStepMetadata(resetTo: ExportJarStep, stepMetadata: IStepMetadata): void {
     if (resetTo === ExportJarStep.ResolveJavaProject) {
         stepMetadata.workspaceFolder = undefined;
-        stepMetadata.projectList = undefined;
+        stepMetadata.projectList = [];
         stepMetadata.mainClass = undefined;
     } else if (resetTo === ExportJarStep.ResolveMainClass) {
         stepMetadata.mainClass = undefined;

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -45,14 +45,15 @@ export namespace ExportJarMessages {
     export enum StepAction {
         FINDEXECUTOR = "find proper executor",
         GOBACK = "come back to previous step",
+        GOAHEAD = "go to next step",
     }
 
     export enum Field {
         ENTRY = "Entry",
         WORKSPACEFOLDER = "Workspace folder",
-        OUTPUTPATH = "Output path",
+        OUTPUTPATH = "Target path",
         MAINCLASS = "Main class",
-        CLASSPATHS = "Classpaths",
+        CLASSPATHS = "Elements",
         PROJECTLIST = "Project list",
     }
 
@@ -125,7 +126,7 @@ export function failMessage(message: string, option?: IMessageOption): void {
 }
 
 export function successMessage(outputFileName: string | undefined): void {
-    if (outputFileName === undefined) {
+    if (!outputFileName) {
         return;
     }
     let openInExplorer: string;

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -61,7 +61,7 @@ export namespace ExportJarMessages {
     export const PROJECT_EMPTY = "No classpath found in the workspace. Please make sure your workspace contains valid Java project(s).";
 
     export function fieldUndefinedMessage(field: Field, currentStep: ExportJarStep): string {
-        return `${field} is not specified properly, current step: ${currentStep}. The export jar process will exit.`;
+        return `The value of ${field} is invalid or has not been specified properly, current step: ${currentStep}. The export jar process will exit.`;
     }
 
     export function stepErrorMessage(action: StepAction, currentStep: ExportJarStep): string {

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -5,6 +5,7 @@ import { EOL, platform } from "os";
 import { posix, win32 } from "path";
 import { commands, Extension, extensions, QuickInputButtons, QuickPick, QuickPickItem, SaveDialogOptions, Uri, window } from "vscode";
 import { sendOperationError } from "vscode-extension-telemetry-wrapper";
+import { Commands } from "../commands";
 import { GenerateJarExecutor } from "./GenerateJarExecutor";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
@@ -12,10 +13,12 @@ import { ResolveJavaProjectExecutor } from "./ResolveJavaProjectExecutor";
 import { ResolveMainClassExecutor } from "./ResolveMainClassExecutor";
 
 export enum ExportJarStep {
-    ResolveJavaProject = "RESOLVEJAVAPROJECT",
-    ResolveMainClass = "RESOLVEMAINCLASS",
-    GenerateJar = "GENERATEJAR",
-    Finish = "FINISH",
+    ResolveJavaProject = "Resolve Java Project",
+    // ResolveTask is a virtual step for error reporting only.
+    ResolveTask = "Resolve task",
+    ResolveMainClass = "Resolve main class",
+    GenerateJar = "Generate Jar",
+    Finish = "Finish",
 }
 
 export const stepMap: Map<ExportJarStep, IExportJarStepExecutor> = new Map<ExportJarStep, IExportJarStepExecutor>([
@@ -35,6 +38,34 @@ export namespace ExportJarConstants {
     export const TEST_DEPENDENCIES: string = "testDependencies";
     export const COMPILE_OUTPUT: string = "compileOutput";
     export const TEST_COMPILE_OUTPUT: string = "testCompileOutput";
+}
+
+export namespace ExportJarMessages {
+
+    export enum StepAction {
+        FINDEXECUTOR = "find proper executor",
+        GOBACK = "come back to previous step",
+    }
+
+    export enum Field {
+        ENTRY = "Entry",
+        WORKSPACEFOLDER = "Workspace folder",
+        OUTPUTPATH = "Output path",
+        MAINCLASS = "Main class",
+        CLASSPATHS = "Classpaths",
+        PROJECTLIST = "Project list",
+    }
+
+    export const JAVAPROJECTS_EMPTY = "No Java workspace found. Please make sure there is at least one valid Java workspace folder in your workspace folders.";
+    export const PROJECT_EMPTY = "No classpath found in the workspace. Please make sure your workspace contains valid Java project(s).";
+
+    export function fieldUndefinedMessage(field: Field, currentStep: ExportJarStep): string {
+        return `${field} is not specified properly, current step: ${currentStep}. The export jar process will exit.`;
+    }
+
+    export function stepErrorMessage(action: StepAction, currentStep: ExportJarStep): string {
+        return `Cannot ${action} in the wizard, current step: ${currentStep}. The export jar process will exit.`;
+    }
 }
 
 export function resetStepMetadata(resetTo: ExportJarStep, stepMetadata: IStepMetadata): void {
@@ -65,7 +96,7 @@ export interface IMessageOption {
     arguments?: any;
 }
 
-export async function saveDialog(workSpaceUri: Uri, title: string): Promise<Uri> {
+export async function saveDialog(workSpaceUri: Uri, title: string): Promise<Uri | undefined> {
     const options: SaveDialogOptions = {
         saveLabel: title,
         defaultUri: workSpaceUri,
@@ -76,8 +107,8 @@ export async function saveDialog(workSpaceUri: Uri, title: string): Promise<Uri>
     return Promise.resolve(await window.showSaveDialog(options));
 }
 
-export function failMessage(message: string, option?: IMessageOption) {
-    sendOperationError("", "Export Jar", new Error(message));
+export function failMessage(message: string, option?: IMessageOption): void {
+    sendOperationError("", Commands.VIEW_PACKAGE_EXPORT_JAR, new Error(message));
     if (option === undefined) {
         window.showErrorMessage(message, "Done");
     } else {
@@ -93,7 +124,10 @@ export function failMessage(message: string, option?: IMessageOption) {
     }
 }
 
-export function successMessage(outputFileName: string) {
+export function successMessage(outputFileName: string | undefined): void {
+    if (outputFileName === undefined) {
+        return;
+    }
     let openInExplorer: string;
     if (platform() === "win32") {
         openInExplorer = "Reveal in File Explorer";


### PR DESCRIPTION
Fix #385 

This PR fixs:
1. Enables null check and implicit any for export jar files
2. Refactor error reporting and telemetry sending in export jar. 