### PR TITLE
fix: Cannot show JDK class node in hierarchical mode

### DIFF
--- a/src/views/hierarchicalPackageNode.ts
+++ b/src/views/hierarchicalPackageNode.ts
@@ -31,7 +31,7 @@ export class HierarchicalPackageNode extends PackageNode {
             if (data) {
                 if (this.nodeData?.children) {
                     this.nodeData.children.push(...data);
-                    this.nodeData.children = _.uniqBy(this.nodeData.children, "path");
+                    this.nodeData.children = _.uniqBy(this.nodeData.children, (child: INodeData) => [child.path, child.name].join());
                 } else {
                     this.nodeData.children = data;
                 }


### PR DESCRIPTION
Since the modular JDK has the same `jrtfs` path. So we need to take its name into consideration as well