### PR TITLE
fix: NPE error when open non-project file

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
@@ -121,10 +121,6 @@ public class PackageCommand {
         String typeRootUri = (String) arguments.get(0);
         List<PackageNode> result = new ArrayList<>();
         URI uri = JDTUtils.toURI(typeRootUri);
-        // return empty list if uri doesn't belong to current project folder
-        if (JDTUtils.findResource(uri, ResourcesPlugin.getWorkspace().getRoot()::findFilesForLocationURI) == null) {
-            return result;
-        }
         ITypeRoot typeRoot = ExtUtils.JDT_SCHEME.equals(uri.getScheme()) ? JDTUtils.resolveClassFile(uri) : JDTUtils.resolveCompilationUnit(uri);
         if (typeRoot != null && typeRoot.findPrimaryType() != null) {
             // Add project node:

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
@@ -121,6 +121,10 @@ public class PackageCommand {
         String typeRootUri = (String) arguments.get(0);
         List<PackageNode> result = new ArrayList<>();
         URI uri = JDTUtils.toURI(typeRootUri);
+        // return empty list if uri doesn't belong to current project folder
+        if (JDTUtils.findResource(uri, ResourcesPlugin.getWorkspace().getRoot()::findFilesForLocationURI) == null) {
+            return result;
+        }
         ITypeRoot typeRoot = ExtUtils.JDT_SCHEME.equals(uri.getScheme()) ? JDTUtils.resolveClassFile(uri) : JDTUtils.resolveCompilationUnit(uri);
         if (typeRoot != null && typeRoot.findPrimaryType() != null) {
             // Add project node:

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { window, workspace, WorkspaceFolder } from "vscode";
+import { Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
+import { languageServerApiManager } from "./languageServerApi/languageServerApiManager";
+import { Settings } from "./settings";
 
 export class Utility {
 
@@ -19,6 +21,19 @@ export class Utility {
             return activeWorkspaceFolder;
         }
         return undefined;
+    }
+
+    public static async isRevealable(uri: Uri): Promise<boolean> {
+        if (!SUPPORTED_URI_SCHEMES.includes(uri.scheme)) {
+            return false;
+        }
+        if (uri.scheme === "file" && !workspace.getWorkspaceFolder(uri)) {
+            return false;
+        }
+        if (!Settings.syncWithFolderExplorer() || !await languageServerApiManager.isStandardServerReady()) {
+            return false;
+        }
+        return true;
     }
 
 }
@@ -60,6 +75,8 @@ const keywords: Set<string> = new Set([
     "interface", "static", "void", "char", "finally", "long", "strictfp", "volatile", "class", "float", "native", "super", "while",
     "const", "for", "new", "switch", "continue", "goto", "package", "synchronized", "true", "false", "null", "assert", "enum",
 ]);
+
+const SUPPORTED_URI_SCHEMES: string[] = ["file", "jdt"];
 
 export function isKeyword(identifier: string): boolean {
     return keywords.has(identifier);

--- a/src/views/dataNode.ts
+++ b/src/views/dataNode.ts
@@ -110,7 +110,7 @@ export abstract class DataNode extends ExplorerNode {
 
     protected abstract get iconPath(): string | Uri | { light: string | Uri; dark: string | Uri } | ThemeIcon;
 
-    protected async abstract loadData(): Promise<any[] | undefined>;
+    protected abstract loadData(): Promise<any[] | undefined>;
 
     protected abstract createChildNodeList(): ExplorerNode[] | undefined;
 }

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -125,7 +125,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         const projects = await this.getRootProjects();
         const project = projects ? <DataNode>projects.find((node: DataNode) =>
             node.path === projectNodeData?.path && node.nodeData.name === projectNodeData?.name) : undefined;
-        return project ? project.revealPaths(paths) : undefined;
+        return project?.revealPaths(paths);
     }
 
     private doRefresh(element?: ExplorerNode): void {

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -4,7 +4,7 @@
 import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as path from "path";
-import { commands, Disposable, ExtensionContext, TextEditor, TreeView, TreeViewVisibilityChangeEvent, Uri, window } from "vscode";
+import { commands, Disposable, ExtensionContext, TextEditor, TreeView, TreeViewVisibilityChangeEvent, Uri, window, workspace } from "vscode";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
 import { Build } from "../constants";
@@ -48,6 +48,10 @@ export class DependencyExplorer implements Disposable {
             window.onDidChangeActiveTextEditor((textEditor: TextEditor) => {
                 if (this._dependencyViewer.visible && textEditor && textEditor.document && Settings.syncWithFolderExplorer()) {
                     const uri: Uri = textEditor.document.uri;
+                    // if editor doesn't belong to workspace, do nothing
+                    if (uri.fsPath === workspace.asRelativePath(uri.fsPath)) {
+                        return;
+                    }
                     if (this.SUPPORTED_URI_SCHEMES.includes(uri.scheme)) {
                         this.reveal(uri);
                     }

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -48,8 +48,8 @@ export class DependencyExplorer implements Disposable {
             window.onDidChangeActiveTextEditor((textEditor: TextEditor) => {
                 if (this._dependencyViewer.visible && textEditor && textEditor.document && Settings.syncWithFolderExplorer()) {
                     const uri: Uri = textEditor.document.uri;
-                    // if editor doesn't belong to workspace, do nothing
-                    if (uri.fsPath === workspace.asRelativePath(uri.fsPath)) {
+                    // if active editor doesn't belong to workspace, do nothing
+                    if (!workspace.getWorkspaceFolder(uri)) {
                         return;
                     }
                     if (this.SUPPORTED_URI_SCHEMES.includes(uri.scheme)) {


### PR DESCRIPTION
When we open a non-java file which doesn't belong to the opened project, LS will throw NPE error, since in `resolvePath` api we assume the file should be in workspace. So, additional checks are needed.

fix #418 