### PR TITLE
feat: Make openFile experience consistent with built-in trees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,9 +176,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.50.0.tgz",
-      "integrity": "sha512-QnIeyi4L2DiD9M2bAQKRzT/EQvc80qP9UL6JD5TiLlNRL1khIDg4ej4mDSRbtFrDAsRntFI1RhMvdomUThMsqg==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "explorer"
   ],
   "engines": {
-    "vscode": "^1.50.0"
+    "vscode": "^1.52.0"
   },
   "repository": {
     "type": "git",
@@ -570,7 +570,7 @@
     "@types/minimatch": "^3.0.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^8.10.66",
-    "@types/vscode": "1.50.0",
+    "@types/vscode": "1.52.0",
     "copy-webpack-plugin": "^6.3.2",
     "glob": "^7.1.6",
     "gulp": "^4.0.2",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,8 +20,6 @@ export namespace Commands {
 
     export const VIEW_PACKAGE_REFRESH = "java.view.package.refresh";
 
-    export const VIEW_PACKAGE_OPEN_FILE = "java.view.package.openFile";
-
     export const VIEW_PACKAGE_OUTLINE = "java.view.package.outline";
 
     export const VIEW_PACKAGE_REVEAL_FILE_OS = "java.view.package.revealFileInOS";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ExtensionContext, tasks } from "vscode";
-import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation } from "vscode-extension-telemetry-wrapper";
+import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { contextManager } from "../extension.bundle";
 import { Build, Context } from "./constants";
 import { LibraryController } from "./controllers/libraryController";
@@ -11,6 +11,7 @@ import { init as initExpService } from "./ExperimentationService";
 import { ExportJarTaskProvider } from "./exportJarSteps/ExportJarTaskProvider";
 import { Settings } from "./settings";
 import { syncHandler } from "./syncHandler";
+import { EventCounter } from "./utility";
 import { DependencyExplorer } from "./views/dependencyExplorer";
 
 export async function activate(context: ExtensionContext): Promise<void> {
@@ -33,6 +34,7 @@ async function activateExtension(_operationId: string, context: ExtensionContext
 }
 
 // this method is called when your extension is deactivated
-export async function deactivate() {
+export async function deactivate(): Promise<void> {
+    sendInfo("", EventCounter.dict);
     await disposeTelemetryWrapper();
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -5,6 +5,7 @@ import { Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
 import { languageServerApiManager } from "./languageServerApi/languageServerApiManager";
 import { Settings } from "./settings";
+import { Lock } from "./utils/Lock";
 
 export class Utility {
 
@@ -36,6 +37,22 @@ export class Utility {
         return true;
     }
 
+}
+
+export class EventCounter {
+    public static dict: {[key: string]: number} = {};
+
+    public static async increase(event: string) {
+        try {
+            await this._lock.acquire();
+            const count = this.dict[event] ?? 0;
+            this.dict[event] = count + 1;
+        } finally {
+            this._lock.release();
+        }
+    }
+
+    private static _lock: Lock = new Lock();
 }
 
 export class UserError extends Error {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -5,7 +5,6 @@ import { Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
 import { languageServerApiManager } from "./languageServerApi/languageServerApiManager";
 import { Settings } from "./settings";
-import { Lock } from "./utils/Lock";
 
 export class Utility {
 
@@ -42,17 +41,10 @@ export class Utility {
 export class EventCounter {
     public static dict: {[key: string]: number} = {};
 
-    public static async increase(event: string) {
-        try {
-            await this._lock.acquire();
-            const count = this.dict[event] ?? 0;
-            this.dict[event] = count + 1;
-        } finally {
-            this._lock.release();
-        }
+    public static increase(event: string) {
+        const count = this.dict[event] ?? 0;
+        this.dict[event] = count + 1;
     }
-
-    private static _lock: Lock = new Lock();
 }
 
 export class UserError extends Error {

--- a/src/views/PrimaryTypeNode.ts
+++ b/src/views/PrimaryTypeNode.ts
@@ -85,8 +85,8 @@ export class PrimaryTypeNode extends DataNode {
     protected get command(): Command {
         return {
             title: "Open source file content",
-            command: Commands.VIEW_PACKAGE_OPEN_FILE,
-            arguments: [this.uri],
+            command: Commands.VSCODE_OPEN,
+            arguments: [Uri.parse(this.uri || ""), { preserveFocus: true }],
         };
     }
 

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -41,8 +41,6 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, (node: DataNode) => newJavaClass(node)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_PACKAGE, (node: DataNode) => newPackage(node)));
-        context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OPEN_FILE, (uri) =>
-            commands.executeCommand(Commands.VSCODE_OPEN, Uri.parse(uri), { preserveFocus: true })));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OUTLINE, (uri, range) =>
             window.showTextDocument(Uri.parse(uri), { selection: range })));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_BUILD_WORKSPACE, () =>

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -4,8 +4,9 @@
 import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as path from "path";
-import { commands, Disposable, ExtensionContext, TextEditor, TreeView, TreeViewVisibilityChangeEvent, Uri, window } from "vscode";
-import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
+import { commands, Disposable, ExtensionContext, TextEditor, TreeView,
+    TreeViewExpansionEvent, TreeViewSelectionChangeEvent, TreeViewVisibilityChangeEvent, Uri, window } from "vscode";
+import { instrumentOperationAsVsCodeCommand, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
 import { Build } from "../constants";
 import { deleteFiles } from "../explorerCommands/delete";
@@ -13,7 +14,7 @@ import { renameFile } from "../explorerCommands/rename";
 import { getCmdNode } from "../explorerCommands/utility";
 import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
-import { Utility } from "../utility";
+import { EventCounter, Utility } from "../utility";
 import { Lock } from "../utils/Lock";
 import { DataNode } from "./dataNode";
 import { DependencyDataProvider } from "./dependencyDataProvider";
@@ -41,6 +42,7 @@ export class DependencyExplorer implements Disposable {
         this._dataProvider = new DependencyDataProvider(context);
         this._dependencyViewer = window.createTreeView("javaProjectExplorer", { treeDataProvider: this._dataProvider, showCollapseAll: true });
 
+        // register reveal events
         context.subscriptions.push(
             window.onDidChangeActiveTextEditor((textEditor: TextEditor | undefined) => {
                 if (this._dependencyViewer.visible && textEditor?.document) {
@@ -52,8 +54,11 @@ export class DependencyExplorer implements Disposable {
 
         context.subscriptions.push(
             this._dependencyViewer.onDidChangeVisibility((e: TreeViewVisibilityChangeEvent) => {
-                if (e.visible && window.activeTextEditor) {
-                    this.reveal(window.activeTextEditor.document.uri);
+                if (e.visible) {
+                    sendInfo("", {projectManagerVisible: 1});
+                    if (window.activeTextEditor) {
+                        this.reveal(window.activeTextEditor.document.uri);
+                    }
                 }
             }),
         );
@@ -77,10 +82,29 @@ export class DependencyExplorer implements Disposable {
 
                 uri = Uri.file(fsPath);
                 if ((await fse.stat(fsPath)).isFile()) {
-                    await commands.executeCommand(Commands.VIEW_PACKAGE_OPEN_FILE, uri);
+                    await commands.executeCommand(Commands.VSCODE_OPEN, uri, { preserveFocus: true });
                 }
 
                 this.reveal(uri);
+            }),
+        );
+
+        // register telemetry events
+        context.subscriptions.push(
+            this._dependencyViewer.onDidChangeSelection(async (_e: TreeViewSelectionChangeEvent<ExplorerNode>) => {
+                await EventCounter.increase("didChangeSelection");
+            }),
+        );
+
+        context.subscriptions.push(
+            this._dependencyViewer.onDidCollapseElement(async (_e: TreeViewExpansionEvent<ExplorerNode>) => {
+                await EventCounter.increase("didCollapseElement");
+            }),
+        );
+
+        context.subscriptions.push(
+            this._dependencyViewer.onDidExpandElement(async (_e: TreeViewExpansionEvent<ExplorerNode>) => {
+                await EventCounter.increase("didExpandElement");
             }),
         );
 

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -50,9 +50,6 @@ export class DependencyExplorer implements Disposable {
                     this.reveal(uri);
                 }
             }),
-        );
-
-        context.subscriptions.push(
             this._dependencyViewer.onDidChangeVisibility((e: TreeViewVisibilityChangeEvent) => {
                 if (e.visible) {
                     sendInfo("", {projectManagerVisible: 1});
@@ -61,17 +58,11 @@ export class DependencyExplorer implements Disposable {
                     }
                 }
             }),
-        );
-
-        context.subscriptions.push(
             this._dataProvider.onDidChangeTreeData(() => {
                 if (window.activeTextEditor) {
                     this.reveal(window.activeTextEditor.document.uri);
                 }
             }),
-        );
-
-        context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_REVEAL_IN_PROJECT_EXPLORER, async (uri: Uri) => {
                 await commands.executeCommand(Commands.JAVA_PROJECT_EXPLORER_FOCUS);
                 let fsPath: string = uri.fsPath;
@@ -91,20 +82,14 @@ export class DependencyExplorer implements Disposable {
 
         // register telemetry events
         context.subscriptions.push(
-            this._dependencyViewer.onDidChangeSelection(async (_e: TreeViewSelectionChangeEvent<ExplorerNode>) => {
-                await EventCounter.increase("didChangeSelection");
+            this._dependencyViewer.onDidChangeSelection((_e: TreeViewSelectionChangeEvent<ExplorerNode>) => {
+                EventCounter.increase("didChangeSelection");
             }),
-        );
-
-        context.subscriptions.push(
-            this._dependencyViewer.onDidCollapseElement(async (_e: TreeViewExpansionEvent<ExplorerNode>) => {
-                await EventCounter.increase("didCollapseElement");
+            this._dependencyViewer.onDidCollapseElement((_e: TreeViewExpansionEvent<ExplorerNode>) => {
+                EventCounter.increase("didCollapseElement");
             }),
-        );
-
-        context.subscriptions.push(
-            this._dependencyViewer.onDidExpandElement(async (_e: TreeViewExpansionEvent<ExplorerNode>) => {
-                await EventCounter.increase("didExpandElement");
+            this._dependencyViewer.onDidExpandElement((_e: TreeViewExpansionEvent<ExplorerNode>) => {
+                EventCounter.increase("didExpandElement");
             }),
         );
 
@@ -116,33 +101,21 @@ export class DependencyExplorer implements Disposable {
                     commands.executeCommand("revealFileInOS", Uri.parse(cmdNode.uri));
                 }
             }),
-        );
-
-        context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_FILE_PATH, (node?: DataNode) => {
                 const cmdNode = getCmdNode(this._dependencyViewer.selection[0], node);
                 if (cmdNode.uri) {
                     commands.executeCommand("copyFilePath", Uri.parse(cmdNode.uri));
                 }
             }),
-        );
-
-        context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_COPY_RELATIVE_FILE_PATH, (node?: DataNode) => {
                 const cmdNode = getCmdNode(this._dependencyViewer.selection[0], node);
                 if (cmdNode.uri) {
                     commands.executeCommand("copyRelativeFilePath", Uri.parse(cmdNode.uri));
                 }
             }),
-        );
-
-        context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_RENAME_FILE, (node?: DataNode) => {
                 renameFile(getCmdNode(this._dependencyViewer.selection[0], node));
             }),
-        );
-
-        context.subscriptions.push(
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node?: DataNode) => {
                 deleteFiles(getCmdNode(this._dependencyViewer.selection[0], node));
             }),

--- a/src/views/fileNode.ts
+++ b/src/views/fileNode.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Command, ThemeIcon } from "vscode";
+import { Command, ThemeIcon, Uri } from "vscode";
 import { Commands } from "../commands";
 import { Explorer } from "../constants";
 import { INodeData } from "../java/nodeData";
@@ -32,8 +32,8 @@ export class FileNode extends DataNode {
     protected get command(): Command {
         return {
             title: "Open file",
-            command: Commands.VIEW_PACKAGE_OPEN_FILE,
-            arguments: [this.uri],
+            command: Commands.VSCODE_OPEN,
+            arguments: [Uri.parse(this.uri || ""), { preserveFocus: true }],
         };
     }
 

--- a/src/views/symbolNode.ts
+++ b/src/views/symbolNode.ts
@@ -16,7 +16,7 @@ export class SymbolNode extends BaseSymbolNode {
 
     public getChildren(): ExplorerNode[] | Promise<ExplorerNode[]> {
         const res: ExplorerNode[] = [];
-        if (this._children && this._children.length) {
+        if (this._children?.length) {
             this._children.forEach((child) => {
                 res.push(new SymbolNode(child, this.getParent() as PrimaryTypeNode));
             });


### PR DESCRIPTION
This PR changes two parts:

1. From VS Code 1.52, all custom tree behavior has been changed, which enable our plugin to have more consistent experience with file explorer when open file. That means, all following interactions are enabled for `fileNode` and `primaryTypeNode`:

- Double-click or mouse-middle-click to open in non-preview.
- Enter to open in non-preview mode (Space to open in preview mode).
- Alt+Click to open an editor to the side of the active one.

reference: [https://code.visualstudio.com/updates/v1_52](ref)

2. Since changes above needs to register `vscode.open` as TreeItem's command id, we can not use customized `java.view.package.openFile` command to send telemetry. As compensate, we send these additional info in telemetry:

- `{projectManagerVisible: 1}` when project manager is expanded
- counter for `didChangeSelection`, `didCollapseElement`, `didExpandElement` events