### PR TITLE
fix: Export Jar wizard shows main classes from libraries

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -194,7 +194,7 @@ public final class ProjectCommand {
         for (PackageNode project : projectList) {
             IJavaProject javaProject = PackageCommand.getJavaProject(project.getUri());
             for (IPackageFragmentRoot packageFragmentRoot : javaProject.getAllPackageFragmentRoots()) {
-                if (!packageFragmentRoot.isExternal()) {
+                if (!packageFragmentRoot.isArchive()) {
                     searchRoots.add(packageFragmentRoot);
                 }
             }


### PR DESCRIPTION
fix #428 