### PR TITLE
Fix add libraries dialog not working on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,13 @@
         "command": "java.project.addLibraries",
         "title": "%contributes.commands.java.project.addLibraries%",
         "category": "Java",
-        "icon": "$(add)"
+        "icon": "$(new-file)"
+      },
+      {
+        "command": "java.project.addLibraryFolders",
+        "title": "%contributes.commands.java.project.addLibraryFolders%",
+        "category": "Java",
+        "icon": "$(new-folder)"
       },
       {
         "command": "java.project.removeLibrary",
@@ -286,6 +292,10 @@
           "when": "false"
         },
         {
+          "command": "java.project.addLibraryFolders",
+          "when": "false"
+        },
+        {
           "command": "java.project.removeLibrary",
           "when": "false"
         },
@@ -469,6 +479,11 @@
           "group": "inline@0"
         },
         {
+          "command": "java.project.addLibraryFolders",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
+          "group": "inline@1"
+        },
+        {
           "command": "java.project.removeLibrary",
           "when": "view == javaProjectExplorer && viewItem =~ /java:jar(?=.*?\\b\\+referencedLibrary\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "inline"
@@ -476,7 +491,7 @@
         {
           "command": "java.project.refreshLibraries",
           "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
-          "group": "inline@1"
+          "group": "inline@2"
         },
         {
           "command": "java.view.package.exportJar",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "command": "java.project.addLibraries",
         "title": "%contributes.commands.java.project.addLibraries%",
         "category": "Java",
-        "icon": "$(new-file)"
+        "icon": "$(add)"
       },
       {
         "command": "java.project.addLibraryFolders",
@@ -475,13 +475,9 @@
         },
         {
           "command": "java.project.addLibraries",
+          "alt": "java.project.addLibraryFolders",
           "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
           "group": "inline@0"
-        },
-        {
-          "command": "java.project.addLibraryFolders",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
-          "group": "inline@1"
         },
         {
           "command": "java.project.removeLibrary",
@@ -491,7 +487,7 @@
         {
           "command": "java.project.refreshLibraries",
           "when": "view == javaProjectExplorer && viewItem =~ /java:container(?=.*?\\b\\+referencedLibrary\\b)/",
-          "group": "inline@2"
+          "group": "inline@1"
         },
         {
           "command": "java.view.package.exportJar",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,8 +1,9 @@
 {
   "description": "Manage Java projects in Visual Studio Code",
   "contributes.commands.java.project.create": "Create Java Project...",
-  "contributes.commands.java.project.addLibraries": "Add a jar file or a folder to project classpath",
-  "contributes.commands.java.project.removeLibrary": "Remove jar file from project classpath",
+  "contributes.commands.java.project.addLibraries": "Add Jar Libraries to Project Classpath...",
+  "contributes.commands.java.project.addLibraryFolders": "Add Library Folders to Project Classpath...",
+  "contributes.commands.java.project.removeLibrary": "Remove Library from Project Classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.project.build.workspace": "Build Workspace",
   "contributes.commands.java.project.clean.workspace": "Clean Workspace",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,7 +3,7 @@
   "contributes.commands.java.project.create": "Create Java Project...",
   "contributes.commands.java.project.addLibraries": "Add Jar Libraries to Project Classpath...",
   "contributes.commands.java.project.addLibraryFolders": "Add Library Folders to Project Classpath...",
-  "contributes.commands.java.project.removeLibrary": "Remove Library from Project Classpath",
+  "contributes.commands.java.project.removeLibrary": "Remove from Project Classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
   "contributes.commands.java.project.build.workspace": "Build Workspace",
   "contributes.commands.java.project.clean.workspace": "Clean Workspace",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,9 +1,9 @@
 {
   "description": "在 Visual Studio Code 中管理 Java 项目",
   "contributes.commands.java.project.create": "创建 Java 项目...",
-  "contributes.commands.java.project.addLibraries": "TRANSLATION NEEDED...",
-  "contributes.commands.java.project.addLibraryFolders": "TRANSLATION NEEDED...",
-  "contributes.commands.java.project.removeLibrary": "TRANSLATION NEEDED? (English wording changed slightly, see previous commit)",
+  "contributes.commands.java.project.addLibraries": "添加 Jar 文件至项目 Classpath...",
+  "contributes.commands.java.project.addLibraryFolders": "添加文件夹至项目 Classpath...",
+  "contributes.commands.java.project.removeLibrary": "从项目 Classpath 中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.project.build.workspace": "构建工作空间",
   "contributes.commands.java.project.clean.workspace": "清理工作空间",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -3,7 +3,7 @@
   "contributes.commands.java.project.create": "创建 Java 项目...",
   "contributes.commands.java.project.addLibraries": "TRANSLATION NEEDED...",
   "contributes.commands.java.project.addLibraryFolders": "TRANSLATION NEEDED...",
-  "contributes.commands.java.project.removeLibrary": "将该 Jar 文件从 Java 项目类路径中移除",
+  "contributes.commands.java.project.removeLibrary": "TRANSLATION NEEDED? (English wording changed slightly, see previous commit)",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.project.build.workspace": "构建工作空间",
   "contributes.commands.java.project.clean.workspace": "清理工作空间",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,7 +1,8 @@
 {
   "description": "在 Visual Studio Code 中管理 Java 项目",
   "contributes.commands.java.project.create": "创建 Java 项目...",
-  "contributes.commands.java.project.addLibraries": "将一个 Jar 文件或一个目录添加到 Java 项目类路径中",
+  "contributes.commands.java.project.addLibraries": "TRANSLATION NEEDED...",
+  "contributes.commands.java.project.addLibraryFolders": "TRANSLATION NEEDED...",
   "contributes.commands.java.project.removeLibrary": "将该 Jar 文件从 Java 项目类路径中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
   "contributes.commands.java.project.build.workspace": "构建工作空间",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,8 @@ export namespace Commands {
 
     export const JAVA_PROJECT_ADD_LIBRARIES = "java.project.addLibraries";
 
+    export const JAVA_PROJECT_ADD_LIBRARY_FOLDERS = "java.project.addLibraryFolders";
+
     export const JAVA_PROJECT_REMOVE_LIBRARY = "java.project.removeLibrary";
 
     export const JAVA_PROJECT_REFRESH_LIBRARIES = "java.project.refreshLibraries";

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -4,6 +4,7 @@
 import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as minimatch from "minimatch";
+import { platform } from "os";
 import * as path from "path";
 import { Disposable, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
@@ -35,13 +36,13 @@ export class LibraryController implements Disposable {
         if (!libraryGlobs) {
             libraryGlobs = [];
             const workspaceFolder: WorkspaceFolder | undefined = Utility.getDefaultWorkspaceFolder();
-            const isWindows = process.platform.indexOf("win") === 0;
+            const isMac = platform() === "darwin";
             const results: Uri[] | undefined = await window.showOpenDialog({
                 defaultUri: workspaceFolder && workspaceFolder.uri,
                 canSelectFiles: true,
-                canSelectFolders: isWindows ? false : true,
+                canSelectFolders: isMac ? true : false,
                 canSelectMany: true,
-                openLabel: isWindows ? "Select jar files" : "Select jar files or directories",
+                openLabel: isMac ? "Select jar files or directories" : "Select jar files",
                 filters: { Library: ["jar"] },
             });
             if (!results) {

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as fse from "fs-extra";
 import * as _ from "lodash";
 import * as minimatch from "minimatch";
 import { platform } from "os";
@@ -57,7 +58,8 @@ export class LibraryController implements Disposable {
             // keep the param: `includeWorkspaceFolder` to false here
             // since the multi-root is not supported well for invisible projects
             const uriPath = workspace.asRelativePath(uri, false);
-            return canSelectFolders ? uriPath + "/**/*.jar" : uriPath;
+            const isLibraryFolder = canSelectFolders || isMac && (await fse.stat(uri.fsPath)).isDirectory();
+            return isLibraryFolder ? uriPath + "/**/*.jar" : uriPath;
         })));
     }
 

--- a/src/controllers/libraryController.ts
+++ b/src/controllers/libraryController.ts
@@ -3,6 +3,7 @@
 
 import * as _ from "lodash";
 import * as minimatch from "minimatch";
+import { platform } from "os";
 import * as path from "path";
 import { Disposable, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
@@ -38,15 +39,16 @@ export class LibraryController implements Disposable {
         Settings.updateReferencedLibraries(setting);
     }
 
-    public async addLibraries(folders?: boolean) {
+    public async addLibraries(canSelectFolders?: boolean) {
         const workspaceFolder: WorkspaceFolder | undefined = Utility.getDefaultWorkspaceFolder();
+        const isMac = platform() === "darwin";
         const results: Uri[] | undefined = await window.showOpenDialog({
             defaultUri: workspaceFolder && workspaceFolder.uri,
-            canSelectFiles: !folders,
-            canSelectFolders: folders,
+            canSelectFiles: !canSelectFolders,
+            canSelectFolders: canSelectFolders || isMac,
             canSelectMany: true,
-            openLabel: folders ? "Select Library Folders" : "Select Jar Libraries",
-            filters: folders ? { Folders: ["*"] } : { "Jar Files": ["jar"] },
+            openLabel: canSelectFolders ? "Select Library Folders" : "Select Jar Libraries",
+            filters: canSelectFolders ? { Folders: ["*"] } : { "Jar Files": ["jar"] },
         });
         if (!results) {
             return;
@@ -55,7 +57,7 @@ export class LibraryController implements Disposable {
             // keep the param: `includeWorkspaceFolder` to false here
             // since the multi-root is not supported well for invisible projects
             const uriPath = workspace.asRelativePath(uri, false);
-            return folders ? uriPath + "/**/*.jar" : uriPath;
+            return canSelectFolders ? uriPath + "/**/*.jar" : uriPath;
         })));
     }
 


### PR DESCRIPTION
Fixes #238

When trying to add a library to `Referenced Libraries` for invisible projects on Linux, all files are grayed out (unselectable), and you can't even navigate into folders. This makes it impossible to add libraries for invisible projects on Linux, unless you modify the settings.json manually.

This is caused by the unclear API docs for [OpenDialogOptions](https://code.visualstudio.com/api/references/vscode-api#OpenDialogOptions), which say:
> A dialog can select files, folders, or both. This is not true for Windows which enforces to open either files or folder, but *not both*.

This extension then assumes that `canSelectFiles` and `canSelectFolders` can be activated at the same time on both macOS and Linux - but it's actually unsupported on both Windows *and Linux* (which is the root cause of the issue).

Behind the scenes, VS Code is using the Electron API to show the file dialog, and the whole situation actually becomes much clearer if you read the [Electron docs for `dialog`](https://www.electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options):
> **Note:** On Windows and Linux an open dialog can not be both a file selector and a directory selector, so if you set `properties` to `['openFile', 'openDirectory']` on these platforms, a directory selector will be shown.

So what currently happens is that this extension requests a file dialog that can select both files and folders on Linux, which Electron then converts to a file dialog that can **only** select folders. That means you can't select any Jar files, and you also can't select (or navigate into) any folders, because they don't match the `jar` file filter.

30ab944 is a very simple fix that just makes sure to only offer directory selection on macOS.

But after implementing this, I felt like it was a bit of a shame that Windows and Linux users were missing this QOL feature, just because of some Electron or OS limitation. So in b2d3702 I added a separate button for adding folders to the `Referenced Libraries`, so that users can also add library folders on Windows and Linux.

Let me know if these changes sound good, and if the naming makes sense for all the buttons/tooltips. I would also like some help with the [Chinese translation for the new/updated button tooltips](https://github.com/0dinD/vscode-java-dependency/commit/b2d3702a40079302578a744877b0fcd68beabce6#diff-1987abce949e250b7899192a0953c3f408d71048617f24c4a91c4d27ce4c69f5), since I don't know any (and I don't really trust Google Translate to do a good job).