### PR TITLE
fix: Command 'Java: Export Jar...' resulted in an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,32 +247,32 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "java.view.package.exportJar",
+          "when": "java:serverMode == Standard"
+        },
+        {
           "command": "java.view.package.refresh",
-          "when": "java:serverMode == Standard && java:projectManagerActivated"
+          "when": "false"
         },
         {
           "command": "java.view.package.changeToHierarchicalPackageView",
-          "when": "java:serverMode == Standard && java:projectManagerActivated"
+          "when": "false"
         },
         {
           "command": "java.view.package.changeToFlatPackageView",
-          "when": "java:serverMode == Standard && java:projectManagerActivated"
+          "when": "false"
         },
         {
           "command": "java.view.package.linkWithFolderExplorer",
-          "when": "java:serverMode == Standard && java:projectManagerActivated"
+          "when": "false"
         },
         {
           "command": "java.view.package.unlinkWithFolderExplorer",
-          "when": "java:serverMode == Standard && java:projectManagerActivated"
+          "when": "false"
         },
         {
           "command": "java.view.package.revealFileInOS",
           "when": "false"
-        },
-        {
-          "command": "java.view.package.exportJar",
-          "when": "java:serverMode == Standard"
         },
         {
           "command": "java.view.package.copyFilePath",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "homepage": "https://github.com/Microsoft/vscode-java-dependency/blob/master/README.md",
   "icon": "logo.png",
   "activationEvents": [
-    "onCommand:java.project.create",
     "onCommand:_java.project.open",
+    "onCommand:java.project.create",
+    "onCommand:java.view.package.exportJar",
     "onCommand:java.view.package.revealInProjectExplorer",
     "onView:javaProjectExplorer"
   ],
@@ -247,23 +248,23 @@
       "commandPalette": [
         {
           "command": "java.view.package.refresh",
-          "when": "java:serverMode == Standard"
+          "when": "java:serverMode == Standard && java:projectManagerActivated"
         },
         {
           "command": "java.view.package.changeToHierarchicalPackageView",
-          "when": "java:serverMode == Standard"
+          "when": "java:serverMode == Standard && java:projectManagerActivated"
         },
         {
           "command": "java.view.package.changeToFlatPackageView",
-          "when": "java:serverMode == Standard"
+          "when": "java:serverMode == Standard && java:projectManagerActivated"
         },
         {
           "command": "java.view.package.linkWithFolderExplorer",
-          "when": "java:serverMode == Standard"
+          "when": "java:serverMode == Standard && java:projectManagerActivated"
         },
         {
           "command": "java.view.package.unlinkWithFolderExplorer",
-          "when": "java:serverMode == Standard"
+          "when": "java:serverMode == Standard && java:projectManagerActivated"
         },
         {
           "command": "java.view.package.revealFileInOS",
@@ -480,7 +481,7 @@
         },
         {
           "command": "java.view.package.exportJar",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:workspace(?=.*?\\b\\+uri\\b)/ && java:serverMode!= LightWeight",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:workspace(?=.*?\\b\\+uri\\b)/ && java:serverMode == Standard",
           "group": "inline"
         },
         {


### PR DESCRIPTION
fix #436 
This PR sorts all available commands contributed by Java Project Manager in the command palette into two kinds.

1. The command which can execute independently from the project view. It will trigger the activation of `Java Project Manager` first.
    - `java.view.package.exportJar`

2. The commands which are related with the project view. Since the users would most trigger them from the project view and the existence of them in the command palette may cause ambiguity, we hide them in the command palette.
    - `java.view.package.refresh`
    - `java.view.package.changeToHierarchicalPackageView`
    - `java.view.package.changeToFlatPackageView`
    - `java.view.package.linkWithFolderExplorer`
    - `java.view.package.unlinkWithFolderExplorer`

Also, a change in the when clause of the **inline** `Export Jar` button to keep consistent with other commands.