### PR TITLE
fix: Close terminal after receiving messages completely

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -257,7 +257,7 @@ public final class ProjectCommand {
     private static void reportExportJarMessage(String terminalId, int severity, String message) {
         if (StringUtils.isNotBlank(message) && StringUtils.isNotBlank(terminalId)) {
             String readableSeverity = getSeverityString(severity);
-            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT, 
+            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT,
                 terminalId, "[" + readableSeverity + "] " + message);
         }
     }

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -72,14 +72,6 @@ public final class ProjectCommand {
 
     private static String COMMAND_EXPORT_JAR_REPORT = "java.view.package.exportJarReport";
 
-    private static enum ExportJarReportType {
-        MESSAGE,
-        SUCCESS,
-        CANCEL,
-        ERROR,
-        EXIT,
-    }
-
     private static class MainClassInfo {
         public String name;
         public String path;
@@ -265,7 +257,7 @@ public final class ProjectCommand {
     private static void reportExportJarMessage(String terminalId, int severity, String message) {
         if (StringUtils.isNotBlank(message) && StringUtils.isNotBlank(terminalId)) {
             String readableSeverity = getSeverityString(severity);
-            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT, ExportJarReportType.MESSAGE,
+            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT, 
                 terminalId, "[" + readableSeverity + "] " + message);
         }
     }

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -72,6 +72,14 @@ public final class ProjectCommand {
 
     private static String COMMAND_EXPORT_JAR_REPORT = "java.view.package.exportJarReport";
 
+    private static enum ExportJarReportType {
+        MESSAGE,
+        SUCCESS,
+        CANCEL,
+        ERROR,
+        EXIT,
+    }
+
     private static class MainClassInfo {
         public String name;
         public String path;
@@ -146,7 +154,7 @@ public final class ProjectCommand {
         String mainClass = gson.fromJson(gson.toJson(arguments.get(0)), String.class);
         Classpath[] classpaths = gson.fromJson(gson.toJson(arguments.get(1)), Classpath[].class);
         String destination = gson.fromJson(gson.toJson(arguments.get(2)), String.class);
-        String taskLabel = gson.fromJson(gson.toJson(arguments.get(3)), String.class);
+        String terminalId = gson.fromJson(gson.toJson(arguments.get(3)), String.class);
         Manifest manifest = new Manifest();
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
         if (mainClass.length() > 0) {
@@ -164,28 +172,28 @@ public final class ProjectCommand {
                     int severity = resultStatus.getSeverity();
                     if (severity == IStatus.OK) {
                         java.nio.file.Path path = java.nio.file.Paths.get(classpath.source);
-                        reportExportJarMessage(taskLabel, IStatus.OK, "Successfully added the file to the exported jar: " + path.getFileName().toString());
+                        reportExportJarMessage(terminalId, IStatus.OK, "Successfully extracted the file to the exported jar: " + path.getFileName().toString());
                         continue;
                     }
                     if (resultStatus.isMultiStatus()) {
                         for (IStatus childStatus : resultStatus.getChildren()) {
-                            reportExportJarMessage(taskLabel, severity, childStatus.getMessage());
+                            reportExportJarMessage(terminalId, severity, childStatus.getMessage());
                         }
                     } else {
-                        reportExportJarMessage(taskLabel, severity, resultStatus.getMessage());
+                        reportExportJarMessage(terminalId, severity, resultStatus.getMessage());
                     }
                 } else {
                     try {
                         writeFile(new File(classpath.source), new Path(classpath.destination), /* areDirectoryEntriesIncluded = */true,
                             /* isCompressed = */true, target, directories);
-                        reportExportJarMessage(taskLabel, IStatus.OK, "Successfully added the file to the exported jar: " + classpath.destination);
+                        reportExportJarMessage(terminalId, IStatus.OK, "Successfully added the file to the exported jar: " + classpath.destination);
                     } catch (CoreException e) {
-                        reportExportJarMessage(taskLabel, IStatus.ERROR, e.getMessage());
+                        reportExportJarMessage(terminalId, IStatus.ERROR, e.getMessage());
                     }
                 }
             }
         } catch (IOException e) {
-            reportExportJarMessage(taskLabel, IStatus.ERROR, e.getMessage());
+            reportExportJarMessage(terminalId, IStatus.ERROR, e.getMessage());
             return false;
         }
         return true;
@@ -254,11 +262,11 @@ public final class ProjectCommand {
         }
     }
 
-    private static void reportExportJarMessage(String taskLabel, int severity, String message) {
-        if (StringUtils.isNotBlank(message) && StringUtils.isNotBlank(taskLabel)) {
+    private static void reportExportJarMessage(String terminalId, int severity, String message) {
+        if (StringUtils.isNotBlank(message) && StringUtils.isNotBlank(terminalId)) {
             String readableSeverity = getSeverityString(severity);
-            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT,
-                taskLabel, "[" + readableSeverity + "] " + message);
+            JavaLanguageServerPlugin.getInstance().getClientConnection().executeClientCommand(COMMAND_EXPORT_JAR_REPORT, ExportJarReportType.MESSAGE,
+                terminalId, "[" + readableSeverity + "] " + message);
         }
     }
 

--- a/src/exportJarSteps/ExportJarTaskProvider.ts
+++ b/src/exportJarSteps/ExportJarTaskProvider.ts
@@ -424,7 +424,7 @@ class ExportJarTaskTerminal implements Pseudoterminal {
     }
 }
 
-export function showExportJarReport(terminalId: string, message: string): void {
+export function appendOutput(terminalId: string, message: string): void {
     const terminal = activeTerminalMap.get(terminalId);
     if (!terminal) {
         return;

--- a/src/exportJarSteps/GenerateJarExecutor.ts
+++ b/src/exportJarSteps/GenerateJarExecutor.ts
@@ -11,7 +11,7 @@ import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IClasspath, IStepMetadata } from "./IStepMetadata";
-import { createPickBox, ExportJarMessages, ExportJarReportType, ExportJarStep, ExportJarTargets, getExtensionApi, toPosixPath } from "./utility";
+import { createPickBox, ExportJarMessages, ExportJarStep, ExportJarTargets, getExtensionApi, toPosixPath } from "./utility";
 
 export class GenerateJarExecutor implements IExportJarStepExecutor {
 
@@ -70,7 +70,7 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
         }, (_progress, token) => {
             return new Promise<boolean>(async (resolve, reject) => {
                 token.onCancellationRequested(() => {
-                    return reject(ExportJarReportType.CANCEL);
+                    return reject();
                 });
                 const mainClass: string | undefined = stepMetadata.mainClass;
                 // For "no main class" option, we get an empty string in stepMetadata.mainClass,
@@ -106,7 +106,7 @@ export class GenerateJarExecutor implements IExportJarStepExecutor {
         }, (_progress, token) => {
             return new Promise<IJarQuickPickItem[]>(async (resolve, reject) => {
                 token.onCancellationRequested(() => {
-                    return reject(ExportJarReportType.CANCEL);
+                    return reject();
                 });
                 const pickItems: IJarQuickPickItem[] = [];
                 const uriSet: Set<string> = new Set<string>();

--- a/src/exportJarSteps/IStepMetadata.ts
+++ b/src/exportJarSteps/IStepMetadata.ts
@@ -8,6 +8,7 @@ import { ExportJarStep } from "./utility";
 export interface IStepMetadata {
     entry?: INodeData;
     taskLabel: string;
+    terminalId?: string;
     workspaceFolder?: WorkspaceFolder;
     mainClass?: string;
     outputPath?: string;

--- a/src/exportJarSteps/ResolveMainClassExecutor.ts
+++ b/src/exportJarSteps/ResolveMainClassExecutor.ts
@@ -6,7 +6,7 @@ import { Disposable, ProgressLocation, QuickInputButtons, QuickPickItem, window 
 import { Jdtls } from "../java/jdtls";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
-import { createPickBox, ExportJarMessages, ExportJarStep } from "./utility";
+import { createPickBox, ExportJarMessages, ExportJarReportType, ExportJarStep } from "./utility";
 
 export class ResolveMainClassExecutor implements IExportJarStepExecutor {
 
@@ -31,7 +31,7 @@ export class ResolveMainClassExecutor implements IExportJarStepExecutor {
         }, (_progress, token) => {
             return new Promise<IMainClassInfo[]>(async (resolve, reject) => {
                 token.onCancellationRequested(() => {
-                    return reject();
+                    return reject(ExportJarReportType.CANCEL);
                 });
                 if (!stepMetadata.workspaceFolder) {
                     return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.WORKSPACEFOLDER, this.currentStep)));

--- a/src/exportJarSteps/ResolveMainClassExecutor.ts
+++ b/src/exportJarSteps/ResolveMainClassExecutor.ts
@@ -6,7 +6,7 @@ import { Disposable, ProgressLocation, QuickInputButtons, QuickPickItem, window 
 import { Jdtls } from "../java/jdtls";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
-import { createPickBox, ExportJarMessages, ExportJarReportType, ExportJarStep } from "./utility";
+import { createPickBox, ExportJarMessages, ExportJarStep } from "./utility";
 
 export class ResolveMainClassExecutor implements IExportJarStepExecutor {
 
@@ -31,7 +31,7 @@ export class ResolveMainClassExecutor implements IExportJarStepExecutor {
         }, (_progress, token) => {
             return new Promise<IMainClassInfo[]>(async (resolve, reject) => {
                 token.onCancellationRequested(() => {
-                    return reject(ExportJarReportType.CANCEL);
+                    return reject();
                 });
                 if (!stepMetadata.workspaceFolder) {
                     return reject(new Error(ExportJarMessages.fieldUndefinedMessage(ExportJarMessages.Field.WORKSPACEFOLDER, this.currentStep)));

--- a/src/exportJarSteps/utility.ts
+++ b/src/exportJarSteps/utility.ts
@@ -6,7 +6,6 @@ import { posix, win32 } from "path";
 import { commands, Extension, extensions, QuickInputButtons, QuickPick, QuickPickItem, Uri, window } from "vscode";
 import { sendOperationError } from "vscode-extension-telemetry-wrapper";
 import { Commands } from "../commands";
-import { activeTerminals } from "./ExportJarTaskProvider";
 import { GenerateJarExecutor } from "./GenerateJarExecutor";
 import { IExportJarStepExecutor } from "./IExportJarStepExecutor";
 import { IStepMetadata } from "./IStepMetadata";
@@ -68,14 +67,6 @@ export namespace ExportJarMessages {
     export function stepErrorMessage(action: StepAction, currentStep: ExportJarStep): string {
         return `Cannot ${action} in the wizard, current step: ${currentStep}. The export jar process will exit.`;
     }
-}
-
-export enum ExportJarReportType {
-    MESSAGE,
-    SUCCESS,
-    CANCEL,  // user cancels when generating jar
-    ERROR,
-    EXIT,  // user exits when picking
 }
 
 export function resetStepMetadata(resetTo: ExportJarStep, stepMetadata: IStepMetadata): void {
@@ -161,18 +152,6 @@ export async function getExtensionApi(): Promise<any> {
         throw new Error("Export jar is not supported in the current version of language server, please check and update your Language Support for Java(TM) by Red Hat.");
     }
     return extensionApi;
-}
-
-export function showExportJarReport(type: ExportJarReportType, terminalId: string, message?: string) {
-    for (const terminal of activeTerminals) {
-        if (terminal.terminalId === terminalId) {
-            if (type !== ExportJarReportType.MESSAGE) {
-                terminal.exit(type);
-            } else if (message) {
-                terminal.writeEmitter.fire(message + EOL);
-            }
-        }
-    }
 }
 
 export function revealTerminal(terminalName: string) {

--- a/src/java/jdtls.ts
+++ b/src/java/jdtls.ts
@@ -29,9 +29,9 @@ export namespace Jdtls {
     }
 
     export async function exportJar(mainClass: string, classpaths: IClasspath[],
-                                    destination: string, taskLabel: string, token: CancellationToken): Promise<boolean | undefined> {
+                                    destination: string, terminalId: string, token: CancellationToken): Promise<boolean | undefined> {
         return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_GENERATEJAR,
-            mainClass, classpaths, destination, taskLabel, token);
+            mainClass, classpaths, destination, terminalId, token);
     }
 
     export enum CompileWorkspaceStatus {

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -11,7 +11,7 @@ import { contextManager } from "../../extension.bundle";
 import { Commands } from "../commands";
 import { Context } from "../constants";
 import { executeExportJarTask } from "../exportJarSteps/ExportJarTaskProvider";
-import { showExportJarReport } from "../exportJarSteps/utility";
+import { ExportJarReportType, showExportJarReport } from "../exportJarSteps/utility";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { languageServerApiManager } from "../languageServerApi/languageServerApiManager";
@@ -36,8 +36,9 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
     constructor(public readonly context: ExtensionContext) {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
-        context.subscriptions.push(commands.registerCommand(Commands.EXPORT_JAR_REPORT, (taskLabel: string, message: string) => {
-            showExportJarReport(taskLabel, message);
+        context.subscriptions.push(commands.registerCommand(Commands.EXPORT_JAR_REPORT, (type: ExportJarReportType,
+                                                                                         terminalId: string, message?: string) => {
+            showExportJarReport(type, terminalId, message);
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
             executeExportJarTask(node);

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -10,8 +10,7 @@ import { instrumentOperation, instrumentOperationAsVsCodeCommand } from "vscode-
 import { contextManager } from "../../extension.bundle";
 import { Commands } from "../commands";
 import { Context } from "../constants";
-import { executeExportJarTask } from "../exportJarSteps/ExportJarTaskProvider";
-import { ExportJarReportType, showExportJarReport } from "../exportJarSteps/utility";
+import { executeExportJarTask, showExportJarReport } from "../exportJarSteps/ExportJarTaskProvider";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { languageServerApiManager } from "../languageServerApi/languageServerApiManager";
@@ -36,9 +35,8 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
     constructor(public readonly context: ExtensionContext) {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
-        context.subscriptions.push(commands.registerCommand(Commands.EXPORT_JAR_REPORT, (type: ExportJarReportType,
-                                                                                         terminalId: string, message?: string) => {
-            showExportJarReport(type, terminalId, message);
+        context.subscriptions.push(commands.registerCommand(Commands.EXPORT_JAR_REPORT, (terminalId: string, message: string) => {
+            showExportJarReport(terminalId, message);
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
             executeExportJarTask(node);

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -10,7 +10,7 @@ import { instrumentOperation, instrumentOperationAsVsCodeCommand } from "vscode-
 import { contextManager } from "../../extension.bundle";
 import { Commands } from "../commands";
 import { Context } from "../constants";
-import { executeExportJarTask, showExportJarReport } from "../exportJarSteps/ExportJarTaskProvider";
+import { appendOutput, executeExportJarTask } from "../exportJarSteps/ExportJarTaskProvider";
 import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { languageServerApiManager } from "../languageServerApi/languageServerApiManager";
@@ -36,7 +36,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         context.subscriptions.push(commands.registerCommand(Commands.VIEW_PACKAGE_REFRESH, (debounce?: boolean, element?: ExplorerNode) =>
             this.refreshWithLog(debounce, element)));
         context.subscriptions.push(commands.registerCommand(Commands.EXPORT_JAR_REPORT, (terminalId: string, message: string) => {
-            showExportJarReport(terminalId, message);
+            appendOutput(terminalId, message);
         }));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_EXPORT_JAR, async (node: INodeData) => {
             executeExportJarTask(node);


### PR DESCRIPTION
fix #506 
This PR includes two things:
- Use `terminalId`, which is a random number, instead of `taskLabel` to indicate the execution terminal in case of two terminals with the same name.
- Close the execution terminal once it receives a ending report.