### PR TITLE
chore: Upgrade to node 14 in GitHub pipelines

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
         
     - name: Install Node.js modules
       run: npm install

--- a/.github/workflows/linuxUI.yml
+++ b/.github/workflows/linuxUI.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
         
     - name: Install Node.js modules
       run: npm install

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
 
     - name: Install Node.js modules
       run: npm install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
         
     - name: Install Node.js modules
       run: npm install

--- a/.github/workflows/windowsUI.yml
+++ b/.github/workflows/windowsUI.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: 14
         
     - name: Install Node.js modules
       run: npm install


### PR DESCRIPTION
Since the newest vsce (2.5.1) requires at least node 14 to run, the current pipelines are broken.