### PR TITLE
fix: Remove file from remote environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,8 +166,8 @@
         "category": "Java"
       },
       {
-        "command": "java.view.package.deleteFilePermanentely",
-        "title": "%contributes.commands.java.view.package.deleteFilePermanentely%",
+        "command": "java.view.package.deleteFilePermanently",
+        "title": "%contributes.commands.java.view.package.deleteFilePermanently%",
         "category": "Java"
       },
       {
@@ -264,7 +264,7 @@
         "when": "java:serverMode == Standard && focusedView == javaProjectExplorer && explorerResourceMoveableToTrash"
       },
       {
-        "command": "java.view.package.deleteFilePermanentely",
+        "command": "java.view.package.deleteFilePermanently",
         "key": "delete",
         "mac": "cmd+backspace",
         "when": "java:serverMode == Standard && focusedView == javaProjectExplorer && !explorerResourceMoveableToTrash"
@@ -342,7 +342,7 @@
           "when": "false"
         },
         {
-          "command": "java.view.package.deleteFilePermanentely",
+          "command": "java.view.package.deleteFilePermanently",
           "when": "false"
         },
         {
@@ -470,12 +470,12 @@
           "group": "7_modification@20"
         },
         {
-          "command": "java.view.package.deleteFilePermanentely",
+          "command": "java.view.package.deleteFilePermanently",
           "when": "view == javaProjectExplorer && !explorerResourceMoveableToTrash && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+(source|resource)\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "7_modification@20"
         },
         {
-          "command": "java.view.package.deleteFilePermanentely",
+          "command": "java.view.package.deleteFilePermanently",
           "when": "view == javaProjectExplorer && !explorerResourceMoveableToTrash && viewItem =~ /java:(file|type|folder)(?=.*?\\b\\+uri\\b)/",
           "group": "7_modification@20"
         },

--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
         "category": "Java"
       },
       {
+        "command": "java.view.package.deleteFilePermanentely",
+        "title": "%contributes.commands.java.view.package.deleteFilePermanentely%",
+        "category": "Java"
+      },
+      {
         "command": "java.view.package.renameFile",
         "title": "%contributes.commands.java.view.package.renameFile%",
         "category": "Java"
@@ -256,7 +261,13 @@
         "command": "java.view.package.moveFileToTrash",
         "key": "delete",
         "mac": "cmd+backspace",
-        "when": "java:serverMode == Standard && focusedView == javaProjectExplorer"
+        "when": "java:serverMode == Standard && focusedView == javaProjectExplorer && explorerResourceMoveableToTrash"
+      },
+      {
+        "command": "java.view.package.deleteFilePermanentely",
+        "key": "delete",
+        "mac": "cmd+backspace",
+        "when": "java:serverMode == Standard && focusedView == javaProjectExplorer && !explorerResourceMoveableToTrash"
       }
     ],
     "menus": {
@@ -328,6 +339,10 @@
         },
         {
           "command": "java.view.package.moveFileToTrash",
+          "when": "false"
+        },
+        {
+          "command": "java.view.package.deleteFilePermanentely",
           "when": "false"
         },
         {
@@ -446,12 +461,22 @@
         },
         {
           "command": "java.view.package.moveFileToTrash",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+(source|resource)\\b)(?=.*?\\b\\+uri\\b)/",
+          "when": "view == javaProjectExplorer && explorerResourceMoveableToTrash && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+(source|resource)\\b)(?=.*?\\b\\+uri\\b)/",
           "group": "7_modification@20"
         },
         {
           "command": "java.view.package.moveFileToTrash",
-          "when": "view == javaProjectExplorer && viewItem =~ /java:(file|type|folder)(?=.*?\\b\\+uri\\b)/",
+          "when": "view == javaProjectExplorer && explorerResourceMoveableToTrash && viewItem =~ /java:(file|type|folder)(?=.*?\\b\\+uri\\b)/",
+          "group": "7_modification@20"
+        },
+        {
+          "command": "java.view.package.deleteFilePermanentely",
+          "when": "view == javaProjectExplorer && !explorerResourceMoveableToTrash && viewItem =~ /java:(package|packageRoot)(?=.*?\\b\\+(source|resource)\\b)(?=.*?\\b\\+uri\\b)/",
+          "group": "7_modification@20"
+        },
+        {
+          "command": "java.view.package.deleteFilePermanentely",
+          "when": "view == javaProjectExplorer && !explorerResourceMoveableToTrash && viewItem =~ /java:(file|type|folder)(?=.*?\\b\\+uri\\b)/",
           "group": "7_modification@20"
         },
         {

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,7 +21,7 @@
   "contributes.commands.java.view.package.newPackage": "New Package",
   "contributes.commands.java.view.package.renameFile": "Rename",
   "contributes.commands.java.view.package.moveFileToTrash": "Delete",
-  "contributes.commands.java.view.package.deleteFilePermanentely": "Delete Permanentely",
+  "contributes.commands.java.view.package.deleteFilePermanently": "Delete Permanently",
   "configuration.java.dependency.showMembers": "Show the members in the explorer",
   "configuration.java.dependency.syncWithFolderExplorer": "Synchronize Java Projects explorer selection with folder explorer",
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,6 +21,7 @@
   "contributes.commands.java.view.package.newPackage": "New Package",
   "contributes.commands.java.view.package.renameFile": "Rename",
   "contributes.commands.java.view.package.moveFileToTrash": "Delete",
+  "contributes.commands.java.view.package.deleteFilePermanentely": "Delete Permanentely",
   "configuration.java.dependency.showMembers": "Show the members in the explorer",
   "configuration.java.dependency.syncWithFolderExplorer": "Synchronize Java Projects explorer selection with folder explorer",
   "configuration.java.dependency.autoRefresh": "Synchronize Java Projects explorer with changes",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -21,6 +21,7 @@
   "contributes.commands.java.view.package.newPackage": "创建包",
   "contributes.commands.java.view.package.renameFile": "重命名",
   "contributes.commands.java.view.package.moveFileToTrash": "删除",
+  "contributes.commands.java.view.package.deleteFilePermanentely": "永久删除",
   "configuration.java.dependency.showMembers": "在 Java 项目管理器中显示成员",
   "configuration.java.dependency.syncWithFolderExplorer": "在 Java 项目管理器中同步关联当前打开的文件",
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -21,7 +21,7 @@
   "contributes.commands.java.view.package.newPackage": "创建包",
   "contributes.commands.java.view.package.renameFile": "重命名",
   "contributes.commands.java.view.package.moveFileToTrash": "删除",
-  "contributes.commands.java.view.package.deleteFilePermanentely": "永久删除",
+  "contributes.commands.java.view.package.deleteFilePermanently": "永久删除",
   "configuration.java.dependency.showMembers": "在 Java 项目管理器中显示成员",
   "configuration.java.dependency.syncWithFolderExplorer": "在 Java 项目管理器中同步关联当前打开的文件",
   "configuration.java.dependency.autoRefresh": "在 Java 项目管理器中自动同步修改",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,7 +40,7 @@ export namespace Commands {
 
     export const VIEW_PACKAGE_MOVE_FILE_TO_TRASH = "java.view.package.moveFileToTrash";
 
-    export const VIEW_PACKAGE_DELETE_FILE_PERMANENTELY = "java.view.package.deleteFilePermanentely";
+    export const VIEW_PACKAGE_DELETE_FILE_PERMANENTLY = "java.view.package.deleteFilePermanently";
 
     export const VIEW_PACKAGE_REVEAL_IN_PROJECT_EXPLORER = "java.view.package.revealInProjectExplorer";
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,6 +40,8 @@ export namespace Commands {
 
     export const VIEW_PACKAGE_MOVE_FILE_TO_TRASH = "java.view.package.moveFileToTrash";
 
+    export const VIEW_PACKAGE_DELETE_FILE_PERMANENTELY = "java.view.package.deleteFilePermanentely";
+
     export const VIEW_PACKAGE_REVEAL_IN_PROJECT_EXPLORER = "java.view.package.revealInProjectExplorer";
 
     export const JAVA_PROJECT_OPEN = "_java.project.open";

--- a/src/explorerCommands/delete.ts
+++ b/src/explorerCommands/delete.ts
@@ -37,7 +37,7 @@ export async function deleteFiles(node: DataNode | undefined, useTrash: boolean)
 
 function getInformationMessage(name: string, isFolder: boolean, useTrash: boolean): string {
     const folderMsg = isFolder ? " and its contents" : "";
-    let msg = `Are you sure you want to ${useTrash ? "" : "permanentely "}delete \'${name}\'${folderMsg}?`;
+    let msg = `Are you sure you want to ${useTrash ? "" : "permanently "}delete \'${name}\'${folderMsg}?`;
 
     if (useTrash) {
         msg += "\n\nYou can restore from the Recycle Bin.";

--- a/src/explorerCommands/delete.ts
+++ b/src/explorerCommands/delete.ts
@@ -2,19 +2,19 @@
 // Licensed under the MIT license.
 
 import { Uri, window, workspace } from "vscode";
+import { sendError } from "vscode-extension-telemetry-wrapper";
 import { DataNode } from "../views/dataNode";
 import { isMutable } from "./utility";
 
-const confirmMessage = "Move to Recycle Bin";
-
-export async function deleteFiles(node?: DataNode): Promise<void> {
+export async function deleteFiles(node: DataNode | undefined, useTrash: boolean): Promise<void> {
     if (!node?.uri || !isMutable(node)) {
         return;
     }
 
     const children = await node.getChildren();
     const isFolder = children && children.length !== 0;
-    const message = getInformationMessage(node.name, isFolder);
+    const message = getInformationMessage(node.name, isFolder, useTrash);
+    const confirmMessage = useTrash ? "Move to Recycle Bin" : "Delete";
 
     const answer: string | undefined = await window.showInformationMessage(
         message,
@@ -23,16 +23,24 @@ export async function deleteFiles(node?: DataNode): Promise<void> {
     );
 
     if (answer === confirmMessage) {
-        workspace.fs.delete(Uri.parse(node.uri), {
-            recursive: true,
-            useTrash: true,
-        });
+        try {
+            await workspace.fs.delete(Uri.parse(node.uri), {
+                recursive: true,
+                useTrash,
+            });
+        } catch (e) {
+            // See: https://github.com/microsoft/vscode-java-dependency/issues/608
+            sendError(new Error("Failed to remove files."));
+        }
     }
 }
 
-function getInformationMessage(name: string, isFolder: boolean): string {
+function getInformationMessage(name: string, isFolder: boolean, useTrash: boolean): string {
     const folderMsg = isFolder ? " and its contents" : "";
-    const msg = `Are you sure you want to delete \'${name}\'${folderMsg}?\n\n`;
-    const additionMsg = "You can restore from the Recycle Bin.";
-    return msg + additionMsg;
+    let msg = `Are you sure you want to ${useTrash ? "" : "permanentely "}delete \'${name}\'${folderMsg}?`;
+
+    if (useTrash) {
+        msg += "\n\nYou can restore from the Recycle Bin.";
+    }
+    return msg;
 }

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -126,7 +126,10 @@ export class DependencyExplorer implements Disposable {
                 renameFile(getCmdNode(this._dependencyViewer.selection, node));
             }),
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node?: DataNode) => {
-                deleteFiles(getCmdNode(this._dependencyViewer.selection, node));
+                deleteFiles(getCmdNode(this._dependencyViewer.selection, node), true);
+            }),
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_DELETE_FILE_PERMANENTELY, (node?: DataNode) => {
+                deleteFiles(getCmdNode(this._dependencyViewer.selection, node), false);
             }),
         );
     }

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -128,7 +128,7 @@ export class DependencyExplorer implements Disposable {
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_MOVE_FILE_TO_TRASH, (node?: DataNode) => {
                 deleteFiles(getCmdNode(this._dependencyViewer.selection, node), true);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_DELETE_FILE_PERMANENTELY, (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_DELETE_FILE_PERMANENTLY, (node?: DataNode) => {
                 deleteFiles(getCmdNode(this._dependencyViewer.selection, node), false);
             }),
         );


### PR DESCRIPTION
fix #608

Since some platform may not contain recycle bin. So we have to check the context key `explorerResourceMoveableToTrash` to make sure the capability is available. The new command `java.view.package.deleteFilePermanentely` is added and be used when recycle bin is not available.

Signed-off-by: sheche <sheche@microsoft.com>