### PR TITLE
ux: Expose rebuild workspace command

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
       },
       {
         "command": "java.project.build.workspace",
-        "title": "%contributes.commands.java.project.build.workspace%"
+        "title": "%contributes.commands.java.project.build.workspace%",
+        "icon": "$(tools)"
       },
       {
         "command": "java.project.clean.workspace",
@@ -398,7 +399,7 @@
           "group": "navigation@20"
         },
         {
-          "command": "java.view.package.refresh",
+          "command": "java.project.build.workspace",
           "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects",
           "group": "navigation@30"
         },
@@ -423,14 +424,14 @@
           "group": "overflow_10@20"
         },
         {
-          "command": "java.project.build.workspace",
+          "command": "java.project.clean.workspace",
           "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects",
           "group": "overflow_20@10"
         },
         {
-          "command": "java.project.clean.workspace",
+          "command": "java.view.package.refresh",
           "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects",
-          "group": "overflow_20@20"
+          "group": "overflow_50@10"
         }
       ],
       "view/item/context": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,7 +5,7 @@
   "contributes.commands.java.project.addLibraryFolders": "Add Library Folders to Project Classpath...",
   "contributes.commands.java.project.removeLibrary": "Remove from Project Classpath",
   "contributes.commands.java.view.package.refresh": "Refresh",
-  "contributes.commands.java.project.build.workspace": "Build Workspace",
+  "contributes.commands.java.project.build.workspace": "Rebuild Workspace",
   "contributes.commands.java.project.clean.workspace": "Clean Workspace",
   "contributes.commands.java.project.update": "Update Project",
   "contributes.commands.java.view.package.revealInProjectExplorer": "Reveal in Java Project Explorer",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -5,7 +5,7 @@
   "contributes.commands.java.project.addLibraryFolders": "添加文件夹至项目 Classpath...",
   "contributes.commands.java.project.removeLibrary": "从项目 Classpath 中移除",
   "contributes.commands.java.view.package.refresh": "刷新",
-  "contributes.commands.java.project.build.workspace": "构建工作空间",
+  "contributes.commands.java.project.build.workspace": "重新构建工作空间",
   "contributes.commands.java.project.clean.workspace": "清理工作空间",
   "contributes.commands.java.project.update": "更新项目",
   "contributes.commands.java.view.package.revealInProjectExplorer": "在 Java 项目视图中显示",

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -44,7 +44,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_OUTLINE, (uri, range) =>
             window.showTextDocument(Uri.parse(uri), { selection: range })));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_BUILD_WORKSPACE, () =>
-            commands.executeCommand(Commands.JAVA_BUILD_WORKSPACE)));
+            commands.executeCommand(Commands.JAVA_BUILD_WORKSPACE, true /*fullCompile*/)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CLEAN_WORKSPACE, () =>
             commands.executeCommand(Commands.JAVA_CLEAN_WORKSPACE)));
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_UPDATE, async (node: INodeData) => {


### PR DESCRIPTION
fix #619 
![image](https://user-images.githubusercontent.com/6193897/172282593-7f080d37-aabf-47e7-949f-1acbe7392d33.png)

![1654568597](https://user-images.githubusercontent.com/6193897/172282419-51bc56d3-b1c9-4f14-b538-2322b81b72fd.jpg)

We will use the `tools` icon for now per discussion [here](https://github.com/microsoft/vscode-codicons/issues/111#issuecomment-1147646310)

Signed-off-by: sheche <sheche@microsoft.com>