### PR TITLE
fix: Use context value to identify the node types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export namespace Explorer {
         File = "file",
         Type = "type",
         Folder = "folder",
+        Symbol = "symbol",
     }
 
     export enum Mime {

--- a/src/views/DragAndDropController.ts
+++ b/src/views/DragAndDropController.ts
@@ -37,7 +37,7 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
         this.addInternalDragDataTransfer(dragItem, treeDataTransfer);
         sendInfo("", {
             dndType: "drag",
-            dragFrom: dragItem.constructor.name,
+            dragFrom: dragItem.computeContextValue() || "unknown",
         });
     }
 
@@ -121,8 +121,8 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
         if (!this.isDraggableNode(source)) {
             sendInfo("", {
                 dndType: "drop",
-                dragFrom: source ? source.constructor.name : "undefined",
-                dropTo: target ? target.constructor.name : "undefined",
+                dragFrom: source?.computeContextValue() || "unknown",
+                dropTo: target?.computeContextValue() || "unknown",
                 draggable: "false",
             });
             return;
@@ -131,8 +131,8 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
         if (!this.isDroppableNode(target)) {
             sendInfo("", {
                 dndType: "drop",
-                dragFrom: source ? source.constructor.name : "undefined",
-                dropTo: target ? target.constructor.name : "undefined",
+                dragFrom: source?.computeContextValue() || "unknown",
+                dropTo: target?.computeContextValue() || "unknown",
                 draggable: "true",
                 droppable: "false",
             });
@@ -149,7 +149,7 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
                     || !(target.getParent() as ProjectNode).isUnmanagedFolder()) {
                 sendInfo("", {
                     dndType: "drop",
-                    dragFrom: source ? source.constructor.name : "undefined",
+                    dragFrom: source?.computeContextValue() || "unknown",
                     dropTo: "Referenced Libraries",
                     draggable: "true",
                     droppable: "false",
@@ -160,7 +160,7 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
             this.addReferencedLibraries([source?.uri!]);
             sendInfo("", {
                 dndType: "drop",
-                dragFrom: source ? source.constructor.name : "undefined",
+                dragFrom: source?.computeContextValue() || "unknown",
                 dropTo: "Referenced Libraries",
                 draggable: "true",
                 droppable: "true",
@@ -170,8 +170,8 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
             await this.move(Uri.parse(source!.uri!), Uri.parse(target.uri!));
             sendInfo("", {
                 dndType: "drop",
-                dragFrom: source ? source.constructor.name : "undefined",
-                dropTo: target ? target.constructor.name : "undefined",
+                dragFrom: source?.computeContextValue() || "unknown",
+                dropTo: target?.computeContextValue() || "unknown",
                 draggable: "true",
                 droppable: "true",
             });
@@ -188,7 +188,7 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
             sendInfo("", {
                 dndType: "drop",
                 dragFrom: "File Explorer",
-                dropTo: target ? target.constructor.name : "undefined",
+                dropTo: target?.computeContextValue() || "unknown",
                 draggable: "true",
                 droppable: "false",
             });
@@ -224,7 +224,7 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
             sendInfo("", {
                 dndType: "drop",
                 dragFrom: "File Explorer",
-                dropTo: target ? target.constructor.name : "undefined",
+                dropTo: target?.computeContextValue() || "unknown",
                 draggable: "true",
                 droppable: "true",
             });
@@ -294,6 +294,8 @@ export class DragAndDropController implements TreeDragAndDropController<Explorer
                 return false;
             } else if (parent instanceof PackageRootNode) {
                 return parent.isSourceRoot();
+            } else if (parent instanceof PackageNode) {
+                return parent.isSourcePackage();
             } else if (parent instanceof ContainerNode) {
                 if (parent.getContainerType() === ContainerType.ReferencedLibrary) {
                     return (parent.getParent() as ProjectNode).isUnmanagedFolder();

--- a/src/views/documentSymbolNode.ts
+++ b/src/views/documentSymbolNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { DocumentSymbol, Range, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { Explorer } from "../constants";
 import { BaseSymbolNode } from "./baseSymbolNode";
 import { ExplorerNode } from "./explorerNode";
 import { PrimaryTypeNode } from "./PrimaryTypeNode";
@@ -34,5 +35,9 @@ export class DocumentSymbolNode extends BaseSymbolNode {
     public get range(): Range {
         // Using `selectionRange` instead of `range` to make sure the cursor will be pointing to the codes, not the comments
         return (<DocumentSymbol>this.symbolInfo).selectionRange;
+    }
+
+    public computeContextValue(): string | undefined {
+        return `java:${Explorer.ContextValueType.Symbol}`;
     }
 }

--- a/src/views/explorerNode.ts
+++ b/src/views/explorerNode.ts
@@ -31,4 +31,6 @@ export abstract class ExplorerNode {
     public abstract getChildren(): ProviderResult<ExplorerNode[]>;
 
     public abstract getTreeItem(): TreeItem | Promise<TreeItem>;
+
+    public abstract computeContextValue(): string | undefined;
 }

--- a/src/views/packageNode.ts
+++ b/src/views/packageNode.ts
@@ -17,6 +17,11 @@ export class PackageNode extends DataNode {
         super(nodeData, parent);
     }
 
+    public isSourcePackage(): boolean {
+        const parentData = <IPackageRootNodeData> this._rootNode.nodeData;
+        return parentData.entryKind === PackageRootKind.K_SOURCE || parentData.kind === NodeKind.Project;
+    }
+
     protected async loadData(): Promise<INodeData[]> {
         return Jdtls.getPackageData({
             kind: NodeKind.Package,

--- a/src/views/symbolNode.ts
+++ b/src/views/symbolNode.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { Range, SymbolInformation, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { Explorer } from "../constants";
 import { ITypeRootNodeData } from "../java/typeRootNodeData";
 import { BaseSymbolNode } from "./baseSymbolNode";
 import { ExplorerNode } from "./explorerNode";
@@ -38,5 +39,9 @@ export class SymbolNode extends BaseSymbolNode {
 
     public get range(): Range {
         return (<SymbolInformation>this.symbolInfo).location.range;
+    }
+
+    public computeContextValue(): string | undefined {
+        return `java:${Explorer.ContextValueType.Symbol}`;
     }
 }


### PR DESCRIPTION
Signed-off-by: Sheng Chen <sheche@microsoft.com>