### PR TITLE
UX: Change export task type to `java (buildArtifact)`

### DIFF
--- a/package.json
+++ b/package.json
@@ -508,7 +508,7 @@
         {
           "command": "java.project.build.workspace",
           "when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+java\\b)(?=.*?\\b\\+uri\\b)/",
-          "group":"8_execution@5"
+          "group": "8_execution@5"
         },
         {
           "command": "java.project.rebuild",
@@ -635,7 +635,7 @@
     ],
     "taskDefinitions": [
       {
-        "type": "java",
+        "type": "java (buildArtifact)",
         "properties": {
           "label": {
             "type": "string",
@@ -722,6 +722,64 @@
             "type": "boolean",
             "default": "true",
             "description": "%taskDefinitions.java.project.build.isFullBuild%"
+          }
+        }
+      },
+      {
+        "type": "java",
+        "when": "java:showDeprecatedTasks",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "%taskDefinitions.java.project.exportJar.label%"
+          },
+          "mainClass": {
+            "type": "string",
+            "description": "%taskDefinitions.java.project.exportJar.mainClass%"
+          },
+          "targetPath": {
+            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "${workspaceFolder}/${workspaceFolderBasename}.jar",
+                  ""
+                ],
+                "enumDescriptions": [
+                  "%configuration.java.project.exportJar.targetPath.workspaceFolder%",
+                  "%configuration.java.project.exportJar.targetPath.select%"
+                ]
+              }
+            ],
+            "description": "%configuration.java.project.exportJar.targetPath.customization%"
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "enum": [
+                    "${compileOutput}",
+                    "${testCompileOutput}",
+                    "${dependencies}",
+                    "${testDependencies}"
+                  ],
+                  "enumDescriptions": [
+                    "%taskDefinitions.java.project.exportJar.compileOutput%",
+                    "%taskDefinitions.java.project.exportJar.testCompileOutput%",
+                    "%taskDefinitions.java.project.exportJar.dependencies%",
+                    "%taskDefinitions.java.project.exportJar.testDependencies%"
+                  ]
+                }
+              ]
+            },
+            "description": "%taskDefinitions.java.project.exportJar.elements%"
           }
         }
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -94,6 +94,8 @@ export namespace Commands {
 
     export const INSTALL_EXTENSION = "java.project.installExtension";
 
+    export const JAVA_UPDATE_DEPRECATED_TASK = "java.updateDeprecatedTask";
+
     /**
      * Commands from Visual Studio Code
      */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export namespace Context {
     export const NO_JAVA_PROJECT: string = "java:noJavaProjects";
     export const WORKSPACE_CONTAINS_BUILD_FILES: string = "java:workspaceContainsBuildFiles";
     export const RELOAD_PROJECT_ACTIVE: string = "java:reloadProjectActive";
+    export const SHOW_DEPRECATED_TASKS: string = "java:showDeprecatedTasks";
 }
 
 export namespace Explorer {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,6 @@ async function activateExtension(_operationId: string, context: ExtensionContext
     });
     // handle deprecated tasks
     context.subscriptions.push(new DiagnosticProvider());
-    await setContextForDeprecatedTasks();
     context.subscriptions.push(languages.registerCodeActionsProvider([{
         scheme: "file",
         pattern: "**/.vscode/tasks.json"
@@ -80,6 +79,7 @@ async function activateExtension(_operationId: string, context: ExtensionContext
             await updateExportTaskType(document, range);
         }
     ));
+    setContextForDeprecatedTasks();
 }
 
 // this method is called when your extension is deactivated

--- a/src/tasks/migration/CodeActionProvider.ts
+++ b/src/tasks/migration/CodeActionProvider.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { Commands } from "../../commands";
+import { ExportJarTaskProvider } from "../../exportJarSteps/ExportJarTaskProvider";
+import { DiagnosticProvider } from "./DiagnosticProvider";
+
+export class CodeActionProvider implements vscode.CodeActionProvider {
+
+    public static JAVA_UPDATE_DEPRECATED_TASK_TITLE = "Update deprecated task";
+    public static JAVA_BUILD_ARTIFACT_TYPE = `"type": "${ExportJarTaskProvider.exportJarType}"`;
+
+    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection,
+                              _context: vscode.CodeActionContext, _token: vscode.CancellationToken): vscode.CodeAction[] | undefined {
+        const diagnostics = vscode.languages.getDiagnostics(document.uri);
+        if (diagnostics?.length) {
+            for (const diagnostic of diagnostics) {
+                if (diagnostic.source !== DiagnosticProvider.DIAGNOSTIC_SOURCE) {
+                    continue;
+                }
+                if (diagnostic.range.contains(range)) {
+                    const updateTaskCommand: vscode.Command = {
+                        command: Commands.JAVA_UPDATE_DEPRECATED_TASK,
+                        title: CodeActionProvider.JAVA_UPDATE_DEPRECATED_TASK_TITLE,
+                        arguments: [
+                            document,
+                            diagnostic.range
+                        ]
+                    };
+                    return [{
+                        title: CodeActionProvider.JAVA_UPDATE_DEPRECATED_TASK_TITLE,
+                        kind: vscode.CodeActionKind.QuickFix,
+                        command: updateTaskCommand
+                    }];
+                }
+            }
+        }
+        return [];
+    }
+}

--- a/src/tasks/migration/DiagnosticProvider.ts
+++ b/src/tasks/migration/DiagnosticProvider.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as _ from "lodash";
+import * as fs from "fs";
+import * as path from "path";
+import * as readline from "readline";
+import * as vscode from "vscode";
+import { getTasksJsonPaths } from "./utils";
+import { DeprecatedExportJarTaskProvider, ExportJarTaskProvider } from "../../exportJarSteps/ExportJarTaskProvider";
+
+export class DiagnosticProvider implements vscode.Disposable {
+    public static DIAGNOSTIC_SOURCE = "Project Manager for Java";
+    public static DEPRECATED_TASK_TYPE_DECLARATION = `\"type\": \"${DeprecatedExportJarTaskProvider.type}\"`;
+    public static DEPRECATED_TASK_TYPE_MESSAGE = `Tasks with type \"${DeprecatedExportJarTaskProvider.type}\" are deprecated and will not be supported in the future, please use \"${ExportJarTaskProvider.exportJarType}\" instead.`;
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    private disposables: vscode.Disposable[] = [];
+    private refreshDiagnosticsTrigger: any;
+
+    constructor() {
+        this.refreshDiagnosticsTrigger = _.debounce(this.refreshDiagnostics, 500 /** ms */);
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection("migrateExportTask");
+        this.disposables.push(this.diagnosticCollection);
+        this.disposables.push(vscode.workspace.onDidChangeTextDocument(async (e) => {
+            if (path.basename(e.document.fileName) === "tasks.json") {
+                this.refreshDiagnosticsTrigger(e.document.uri);
+            }
+        }));
+        this.initializeDiagnostics();
+    }
+
+    public dispose() {
+        for (const d of this.disposables) {
+            d.dispose();
+        }
+    }
+
+    private async initializeDiagnostics(): Promise<void> {
+        const tasksJsonPaths = await getTasksJsonPaths();
+        for (const tasksJsonPath of tasksJsonPaths) {
+            const diagnostics: vscode.Diagnostic[] = await DiagnosticProvider.getDiagnosticsFromTasksJsonPath(tasksJsonPath);
+            this.diagnosticCollection.set(vscode.Uri.file(tasksJsonPath), diagnostics);
+        }
+    }
+
+    private async refreshDiagnostics(uri: vscode.Uri): Promise<void> {
+        const diagnostics: vscode.Diagnostic[] = await DiagnosticProvider.getDiagnosticsFromTasksJsonPath(uri.fsPath);
+        this.diagnosticCollection.set(uri, diagnostics);
+    }
+
+    private static async getDiagnosticsFromTasksJsonPath(tasksJsonPath: string): Promise<vscode.Diagnostic[]> {
+        const diagnostics: vscode.Diagnostic[] = [];
+        const fileStream = fs.createReadStream(tasksJsonPath);
+        let lineNumber = 0;
+        const rl = readline.createInterface({
+            input: fileStream,
+            crlfDelay: Infinity
+        });
+        for await (const line of rl) {
+            const regExp: RegExp = /\"type\":\s*\"java\"/g;
+            const result: RegExpMatchArray | null = line.match(regExp);
+            if (result?.length === 1) {
+                const matchString = result[0];
+                const columnNumber = line.indexOf(matchString);
+                if (columnNumber > -1) {
+                    const diagnostic = new vscode.Diagnostic(
+                        new vscode.Range(
+                            new vscode.Position(lineNumber, columnNumber),
+                            new vscode.Position(lineNumber, columnNumber + matchString.length)
+                        ),
+                        DiagnosticProvider.DEPRECATED_TASK_TYPE_MESSAGE,
+                        vscode.DiagnosticSeverity.Warning
+                    );
+                    diagnostic.source = DiagnosticProvider.DIAGNOSTIC_SOURCE;
+                    diagnostics.push(diagnostic);
+                }
+            }
+            lineNumber++;
+        }
+        return diagnostics;
+    }
+}

--- a/src/tasks/migration/utils.ts
+++ b/src/tasks/migration/utils.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fse from "fs-extra";
+import * as path from "path";
+import { Range, tasks, TextDocument, workspace, WorkspaceEdit } from "vscode";
+import { DeprecatedExportJarTaskProvider } from "../../exportJarSteps/ExportJarTaskProvider";
+import { contextManager } from "../../contextManager";
+import { Context } from "../../constants";
+import { CodeActionProvider } from "./CodeActionProvider";
+
+export async function getTasksJsonPaths(): Promise<string[]> {
+    const tasksJsonPaths = [];
+    if (workspace.workspaceFolders?.length) {
+        for (const folder of workspace.workspaceFolders) {
+            const tasksJsonPath = path.join(folder.uri.fsPath, ".vscode", "tasks.json");
+            if (await fse.pathExists(tasksJsonPath)) {
+                tasksJsonPaths.push(tasksJsonPath);
+            }
+        }
+    }
+    return tasksJsonPaths;
+}
+
+export async function updateExportTaskType(document: TextDocument, range: Range): Promise<void> {
+    const workspaceEdit = new WorkspaceEdit();
+    workspaceEdit.replace(document.uri, range, CodeActionProvider.JAVA_BUILD_ARTIFACT_TYPE);
+    await workspace.applyEdit(workspaceEdit);
+    await document.save();
+}
+
+export async function setContextForDeprecatedTasks(): Promise<void> {
+    await contextManager.setContextValue(Context.SHOW_DEPRECATED_TASKS, true);
+    const deprecatedTasks = await tasks.fetchTasks({ type: DeprecatedExportJarTaskProvider.type });
+    if (deprecatedTasks?.length) {
+        return;
+    }
+    await contextManager.setContextValue(Context.SHOW_DEPRECATED_TASKS, false);
+}

--- a/test/maven-suite/exportJar.test.ts
+++ b/test/maven-suite/exportJar.test.ts
@@ -20,7 +20,7 @@ suite("Export Jar Tests", () => {
 
     test("Can export jar correctly", async function() {
         const vscodeTasks: Task[] = await tasks.fetchTasks();
-        const exportJarTask: Task | undefined = vscodeTasks.find((t: Task) => t.name === "java: exportjar:maven");
+        const exportJarTask: Task | undefined = vscodeTasks.find((t: Task) => t.name === "java (buildArtifact): maven");
         assert.ok(exportJarTask !== undefined);
 
         await new Promise<void>(async (resolve) => {

--- a/test/maven/.vscode/tasks.json
+++ b/test/maven/.vscode/tasks.json
@@ -2,8 +2,8 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "type": "java",
-            "label": "java: exportjar:maven",
+            "type": "java (buildArtifact)",
+            "label": "java (buildArtifact): maven",
             "mainClass": "com.mycompany.app.App",
             "targetPath": "${workspaceFolder}/${workspaceFolderBasename}.jar",
             "elements": [


### PR DESCRIPTION
fix #665 

This pr also renames the default label from `java: exportjar:${workspaceName}` to `java (buildArtifact): ${workspaceName}`. We can still find `java` type via `Run Tasks...`, but the provider will not provide any template tasks anymore. If there is no `java` tasks in your tasks.json, the result of clicking `java` type will be empty.

![image](https://user-images.githubusercontent.com/45906942/179680067-ae119491-6989-4b39-a41f-5ad6b1bae3ef.png)
