### PR TITLE
fix: Make export jar task unblock fetch task process

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -23,5 +23,8 @@ export { DependencyExplorer } from "./src/views/dependencyExplorer";
 export { Commands } from "./src/commands";
 export { LanguageServerMode } from "./src/languageServerApi/LanguageServerMode";
 
+// language server api
+export { languageServerApiManager } from "./src/languageServerApi/languageServerApiManager";
+
 // tasks
 export { BuildTaskProvider, categorizePaths, getFinalPaths } from "./src/tasks/build/buildTaskProvider";

--- a/src/languageServerApi/languageServerApiManager.ts
+++ b/src/languageServerApi/languageServerApiManager.ts
@@ -12,10 +12,10 @@ import { LanguageServerMode } from "./LanguageServerMode";
 class LanguageServerApiManager {
     private extensionApi: any;
 
-    private isReady: boolean = false;
+    private isServerReady: boolean = false;
 
     public async ready(): Promise<boolean> {
-        if (this.isReady) {
+        if (this.isServerReady) {
             return true;
         }
 
@@ -29,7 +29,7 @@ class LanguageServerApiManager {
         }
 
         await this.extensionApi.serverReady();
-        this.isReady = true;
+        this.isServerReady = true;
         return true;
     }
 
@@ -80,6 +80,15 @@ class LanguageServerApiManager {
 
     private isApiInitialized(): boolean {
         return this.extensionApi !== undefined;
+    }
+
+    /**
+     * Check if the language server is ready in the given timeout.
+     * @param timeout the timeout in milliseconds to wait
+     * @returns false if the language server is not ready in the given timeout, otherwise true
+     */
+    public isReady(timeout: number): Promise<boolean> {
+        return Promise.race([this.ready(), new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeout))]);
     }
 }
 

--- a/src/tasks/buildArtifact/BuildArtifactTaskProvider.ts
+++ b/src/tasks/buildArtifact/BuildArtifactTaskProvider.ts
@@ -99,8 +99,7 @@ export class BuildArtifactTaskProvider implements TaskProvider {
     }
 
     public static async resolveExportTask(task: Task, type: string): Promise<Task> {
-        const languageServerStatus = await Promise.race([languageServerApiManager.ready(), BuildArtifactTaskProvider.getLanguageServerStatusTimeout()]);
-        if (!languageServerStatus) {
+        if (!await languageServerApiManager.isReady(1000)) {
             return task;
         }
         const definition: IExportJarTaskDefinition = <IExportJarTaskDefinition>task.definition;
@@ -128,8 +127,7 @@ export class BuildArtifactTaskProvider implements TaskProvider {
     }
 
     public async provideTasks(): Promise<Task[] | undefined> {
-        const languageServerStatus = await Promise.race([languageServerApiManager.ready(), BuildArtifactTaskProvider.getLanguageServerStatusTimeout()]);
-        if (!languageServerStatus) {
+        if (!await languageServerApiManager.isReady(1000)) {
             return undefined;
         }
         const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
@@ -182,10 +180,6 @@ export class BuildArtifactTaskProvider implements TaskProvider {
             }
         }
         return this.tasks;
-    }
-
-    private static getLanguageServerStatusTimeout(): Promise<boolean> {
-        return new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 1000));
     }
 }
 

--- a/src/tasks/buildArtifact/BuildArtifactTaskProvider.ts
+++ b/src/tasks/buildArtifact/BuildArtifactTaskProvider.ts
@@ -99,30 +99,37 @@ export class BuildArtifactTaskProvider implements TaskProvider {
     }
 
     public static async resolveExportTask(task: Task, type: string): Promise<Task> {
-        if (!await languageServerApiManager.ready()) {
+        const languageServerStatus = await Promise.race([languageServerApiManager.ready(), BuildArtifactTaskProvider.getLanguageServerStatusTimeout()]);
+        if (!languageServerStatus) {
             return task;
         }
         const definition: IExportJarTaskDefinition = <IExportJarTaskDefinition>task.definition;
         const folder: WorkspaceFolder = <WorkspaceFolder>task.scope;
-        const resolvedTask: Task = new Task(definition, folder, task.name, type,
-            new CustomExecution(async (resolvedDefinition: IExportJarTaskDefinition): Promise<Pseudoterminal> => {
-                const stepMetadata: IStepMetadata = {
-                    entry: undefined,
-                    taskLabel: resolvedDefinition.label || folder.name,
-                    workspaceFolder: folder,
-                    projectList: await Jdtls.getProjects(folder.uri.toString()),
-                    steps: [],
-                    elements: [],
-                    classpaths: [],
-                };
-                return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
-            }));
-        resolvedTask.presentationOptions.reveal = TaskRevealKind.Never;
-        return resolvedTask;
+        try {
+            const projectList = await Jdtls.getProjects(folder.uri.toString());
+            const resolvedTask: Task = new Task(definition, folder, task.name, type,
+                new CustomExecution(async (resolvedDefinition: IExportJarTaskDefinition): Promise<Pseudoterminal> => {
+                    const stepMetadata: IStepMetadata = {
+                        entry: undefined,
+                        taskLabel: resolvedDefinition.label || folder.name,
+                        workspaceFolder: folder,
+                        projectList: projectList,
+                        steps: [],
+                        elements: [],
+                        classpaths: [],
+                    };
+                    return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
+                }));
+            resolvedTask.presentationOptions.reveal = TaskRevealKind.Never;
+            return resolvedTask;
+        } catch (e) {
+            return task;
+        }
     }
 
     public async provideTasks(): Promise<Task[] | undefined> {
-        if (!await languageServerApiManager.ready()) {
+        const languageServerStatus = await Promise.race([languageServerApiManager.ready(), BuildArtifactTaskProvider.getLanguageServerStatusTimeout()]);
+        if (!languageServerStatus) {
             return undefined;
         }
         const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
@@ -134,43 +141,51 @@ export class BuildArtifactTaskProvider implements TaskProvider {
         }
         this.tasks = [];
         for (const folder of folders) {
-            const projectList: INodeData[] = await Jdtls.getProjects(folder.uri.toString());
-            const elementList: string[] = [];
-            if (_.isEmpty(projectList)) {
-                continue;
-            } else if (projectList.length === 1) {
-                elementList.push("${" + ExportJarConstants.COMPILE_OUTPUT + "}",
-                    "${" + ExportJarConstants.DEPENDENCIES + "}");
-            } else {
-                for (const project of projectList) {
-                    elementList.push("${" + ExportJarConstants.COMPILE_OUTPUT + ":" + project.name + "}",
-                        "${" + ExportJarConstants.DEPENDENCIES + ":" + project.name + "}");
+            try {
+                const projectList: INodeData[] = await Jdtls.getProjects(folder.uri.toString());
+                const elementList: string[] = [];
+                if (_.isEmpty(projectList)) {
+                    continue;
+                } else if (projectList.length === 1) {
+                    elementList.push("${" + ExportJarConstants.COMPILE_OUTPUT + "}",
+                        "${" + ExportJarConstants.DEPENDENCIES + "}");
+                } else {
+                    for (const project of projectList) {
+                        elementList.push("${" + ExportJarConstants.COMPILE_OUTPUT + ":" + project.name + "}",
+                            "${" + ExportJarConstants.DEPENDENCIES + ":" + project.name + "}");
+                    }
                 }
+                const mainClasses: IMainClassInfo[] = await Jdtls.getMainClasses(folder.uri.toString());
+                const defaultDefinition: IExportJarTaskDefinition = {
+                    type: BuildArtifactTaskProvider.exportJarType,
+                    mainClass: (mainClasses.length === 1) ? mainClasses[0].name : undefined,
+                    targetPath: Settings.getExportJarTargetPath(),
+                    elements: elementList,
+                };
+                const defaultTask: Task = new Task(defaultDefinition, folder, folder.name, BuildArtifactTaskProvider.exportJarType,
+                    new CustomExecution(async (resolvedDefinition: IExportJarTaskDefinition): Promise<Pseudoterminal> => {
+                        const stepMetadata: IStepMetadata = {
+                            entry: undefined,
+                            taskLabel: resolvedDefinition.label || folder.name,
+                            workspaceFolder: folder,
+                            projectList: projectList,
+                            steps: [],
+                            elements: [],
+                            classpaths: [],
+                        };
+                        return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
+                    }), undefined);
+                defaultTask.presentationOptions.reveal = TaskRevealKind.Never;
+                this.tasks.push(defaultTask);
+            } catch (e) {
+                continue;
             }
-            const mainClasses: IMainClassInfo[] = await Jdtls.getMainClasses(folder.uri.toString());
-            const defaultDefinition: IExportJarTaskDefinition = {
-                type: BuildArtifactTaskProvider.exportJarType,
-                mainClass: (mainClasses.length === 1) ? mainClasses[0].name : undefined,
-                targetPath: Settings.getExportJarTargetPath(),
-                elements: elementList,
-            };
-            const defaultTask: Task = new Task(defaultDefinition, folder, folder.name, BuildArtifactTaskProvider.exportJarType,
-                new CustomExecution(async (resolvedDefinition: IExportJarTaskDefinition): Promise<Pseudoterminal> => {
-                    const stepMetadata: IStepMetadata = {
-                        entry: undefined,
-                        taskLabel: resolvedDefinition.label || folder.name,
-                        workspaceFolder: folder,
-                        projectList: await Jdtls.getProjects(folder.uri.toString()),
-                        steps: [],
-                        elements: [],
-                        classpaths: [],
-                    };
-                    return new ExportJarTaskTerminal(resolvedDefinition, stepMetadata);
-                }), undefined);
-            defaultTask.presentationOptions.reveal = TaskRevealKind.Never;
-            this.tasks.push(defaultTask);
         }
         return this.tasks;
+    }
+
+    private static getLanguageServerStatusTimeout(): Promise<boolean> {
+        return new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 1000));
     }
 }
 

--- a/test/maven-suite/buildArtifact.test.ts
+++ b/test/maven-suite/buildArtifact.test.ts
@@ -7,6 +7,7 @@ import * as fse from "fs-extra";
 import { suiteTeardown } from "mocha";
 import * as path from "path";
 import { Task, TaskEndEvent, tasks, workspace } from "vscode";
+import { languageServerApiManager } from "../../extension.bundle";
 import { setupTestEnv } from "../shared";
 
 // tslint:disable: only-arrow-functions
@@ -18,7 +19,14 @@ suite("Build Artifact Tests", () => {
 
     suiteSetup(setupTestEnv);
 
+    test("Should bypass buildArtifact tasks before language server is ready", async function() {
+        const vscodeTasks: Task[] = await tasks.fetchTasks();
+        const buildJarTask: Task | undefined = vscodeTasks.find((t: Task) => t.name === "java (buildArtifact): maven");
+        assert.ok(buildJarTask === undefined);
+    });
+
     test("Can build jar correctly", async function() {
+        await languageServerApiManager.ready();
         const vscodeTasks: Task[] = await tasks.fetchTasks();
         const buildJarTask: Task | undefined = vscodeTasks.find((t: Task) => t.name === "java (buildArtifact): maven");
         assert.ok(buildJarTask !== undefined);


### PR DESCRIPTION
fix #720 

This PR contains two things:

- catch potential exceptions when sending request to jdtls
- wait 1s at most when getting the language server status. Once timeout, will directly return original task (when resolving tasks) or undefined (when providing tasks)