### PR TITLE
refactor: Use factory pattern to create explorer nodes

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/NodeKind.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/NodeKind.java
@@ -16,13 +16,13 @@ public enum NodeKind {
 
     PROJECT(2),
 
-    CONTAINER(3),
+    PACKAGEROOT(3),
 
-    PACKAGEROOT(4),
+    PACKAGE(4),
 
-    PACKAGE(5),
+    PRIMARYTYPE(5),
 
-    PRIMARYTYPE(6),
+    CONTAINER(6),
 
     FOLDER(7),
 

--- a/package.json
+++ b/package.json
@@ -792,7 +792,7 @@
     ]
   },
   "scripts": {
-    "compile": "tsc -p . && webpack --config webpack.config.js",
+    "compile": "tsc -p . && webpack --config webpack.config.js --mode development",
     "watch": "webpack --mode development --watch",
     "test": "tsc -p . && node ./dist/test/index.js",
     "test-ui": "tsc -p . && node ./dist/test/ui/index.js",

--- a/src/java/nodeData.ts
+++ b/src/java/nodeData.ts
@@ -4,10 +4,10 @@
 export enum NodeKind {
     Workspace = 1,
     Project = 2,
-    Container = 3,
-    PackageRoot = 4,
-    Package = 5,
-    PrimaryType = 6,
+    PackageRoot = 3,
+    Package = 4,
+    PrimaryType = 5,
+    Container = 6,
     Folder = 7,
     File = 8,
 }

--- a/src/views/containerNode.ts
+++ b/src/views/containerNode.ts
@@ -8,7 +8,6 @@ import { INodeData, NodeKind } from "../java/nodeData";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
 import { NodeFactory } from "./nodeFactory";
-import { PackageRootNode } from "./packageRootNode";
 import { ProjectNode } from "./projectNode";
 
 export class ContainerNode extends DataNode {
@@ -37,15 +36,15 @@ export class ContainerNode extends DataNode {
     protected async loadData(): Promise<INodeData[]> {
         return Jdtls.getPackageData({ kind: NodeKind.Container, projectUri: this._project.uri, path: this.path });
     }
+
     protected createChildNodeList(): ExplorerNode[] {
-        const result: PackageRootNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
-            this.sort();
-            this.nodeData.children.forEach((classpathNode) => {
-                result.push(NodeFactory.createPackageRootNode(classpathNode, this, this._project));
+            this.nodeData.children.forEach((nodeData) => {
+                result.push(NodeFactory.createNode(nodeData, this, this._project));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     protected get contextValue(): string {

--- a/src/views/dataNode.ts
+++ b/src/views/dataNode.ts
@@ -77,6 +77,7 @@ export abstract class DataNode extends ExplorerNode {
                 const data = await this.loadData();
                 this._nodeData.children = data;
                 this._childrenNodes = this.createChildNodeList() || [];
+                this.sort();
                 return this._childrenNodes;
             }
             return this._childrenNodes;
@@ -97,12 +98,15 @@ export abstract class DataNode extends ExplorerNode {
     }
 
     protected sort() {
-        this.nodeData.children?.sort((a: INodeData, b: INodeData) => {
-            if (a.kind === b.kind) {
-                return a.name < b.name ? -1 : 1;
-            } else {
-                return a.kind - b.kind;
+        this._childrenNodes.sort((a: ExplorerNode, b: ExplorerNode) => {
+            if (a instanceof DataNode && b instanceof DataNode) {
+                if (a.nodeData.kind === b.nodeData.kind) {
+                    return a.nodeData.name < b.nodeData.name ? -1 : 1;
+                } else {
+                    return a.nodeData.kind - b.nodeData.kind;
+                }
             }
+            return 0;
         });
     }
 

--- a/src/views/folderNode.ts
+++ b/src/views/folderNode.ts
@@ -7,11 +7,11 @@ import { Jdtls } from "../java/jdtls";
 import { INodeData, NodeKind } from "../java/nodeData";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
-import { FileNode } from "./fileNode";
 import { ProjectNode } from "./projectNode";
+import { NodeFactory } from "./nodeFactory";
 
 export class FolderNode extends DataNode {
-    constructor(nodeData: INodeData, parent: DataNode, private _project: ProjectNode, private _rootNode: DataNode) {
+    constructor(nodeData: INodeData, parent: DataNode, private _project: ProjectNode, private _rootNode?: DataNode) {
         super(nodeData, parent);
     }
 
@@ -20,24 +20,19 @@ export class FolderNode extends DataNode {
             kind: NodeKind.Folder,
             projectUri: this._project.uri,
             path: this.path,
-            rootPath: this._rootNode.path,
-            handlerIdentifier: this._rootNode.handlerIdentifier,
+            rootPath: this._rootNode?.path,
+            handlerIdentifier: this._rootNode?.handlerIdentifier,
         });
     }
 
     protected createChildNodeList(): ExplorerNode[] {
-        const result: ExplorerNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
-            this.sort();
             this.nodeData.children.forEach((nodeData) => {
-                if (nodeData.kind === NodeKind.File) {
-                    result.push(new FileNode(nodeData, this));
-                } else if (nodeData.kind === NodeKind.Folder) {
-                    result.push(new FolderNode(nodeData, this, this._project, this._rootNode));
-                }
+                result.push(NodeFactory.createNode(nodeData, this, this._project, this._rootNode));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     protected get iconPath(): ThemeIcon {

--- a/src/views/hierarchicalPackageNode.ts
+++ b/src/views/hierarchicalPackageNode.ts
@@ -36,7 +36,9 @@ export class HierarchicalPackageNode extends PackageNode {
                     this.nodeData.children = data;
                 }
             }
-            return this.createChildNodeList();
+            this._childrenNodes = this.createChildNodeList() || [];
+            this.sort();
+            return this._childrenNodes;
         } finally {
             explorerLock.release();
         }

--- a/src/views/hierarchicalPackageNode.ts
+++ b/src/views/hierarchicalPackageNode.ts
@@ -4,15 +4,13 @@
 import * as _ from "lodash";
 import { TreeItem, TreeItemCollapsibleState } from "vscode";
 import { HierarchicalPackageNodeData } from "../java/hierarchicalPackageNodeData";
-import { INodeData, NodeKind } from "../java/nodeData";
+import { INodeData } from "../java/nodeData";
 import { explorerLock } from "../utils/Lock";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
-import { FileNode } from "./fileNode";
-import { FolderNode } from "./folderNode";
 import { PackageNode } from "./packageNode";
-import { PrimaryTypeNode } from "./PrimaryTypeNode";
 import { ProjectNode } from "./projectNode";
+import { NodeFactory } from "./nodeFactory";
 
 export class HierarchicalPackageNode extends PackageNode {
 
@@ -64,24 +62,13 @@ export class HierarchicalPackageNode extends PackageNode {
     }
 
     protected createChildNodeList(): ExplorerNode[] {
-        const result: ExplorerNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
-            this.sort();
             this.nodeData.children.forEach((nodeData) => {
-                if (nodeData.kind === NodeKind.File) {
-                    result.push(new FileNode(nodeData, this));
-                } else if (nodeData instanceof HierarchicalPackageNodeData) {
-                    result.push(new HierarchicalPackageNode(nodeData, this, this._project, this._rootNode));
-                } else if (nodeData.kind === NodeKind.PrimaryType) {
-                    if (nodeData.metaData && nodeData.metaData[PrimaryTypeNode.K_TYPE_KIND]) {
-                        result.push(new PrimaryTypeNode(nodeData, this, this._rootNode));
-                    }
-                } else if (nodeData.kind === NodeKind.Folder) {
-                    result.push(new FolderNode(nodeData, this, this._project, this._rootNode));
-                }
+                result.push(NodeFactory.createNode(nodeData, this, this._project, this._rootNode));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     private getHierarchicalNodeData(): HierarchicalPackageNodeData {

--- a/src/views/nodeFactory.ts
+++ b/src/views/nodeFactory.ts
@@ -1,16 +1,91 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { INodeData } from "../java/nodeData";
+import { sendError } from "vscode-extension-telemetry-wrapper";
+import { INodeData, NodeKind } from "../java/nodeData";
 import { Settings } from "../settings";
+import { PrimaryTypeNode } from "./PrimaryTypeNode";
+import { ContainerNode } from "./containerNode";
 import { DataNode } from "./dataNode";
+import { ExplorerNode } from "./explorerNode";
+import { FileNode } from "./fileNode";
+import { FolderNode } from "./folderNode";
+import { HierarchicalPackageNode } from "./hierarchicalPackageNode";
 import { HierarchicalPackageRootNode } from "./hierarchicalPackageRootNode";
+import { PackageNode } from "./packageNode";
 import { PackageRootNode } from "./packageRootNode";
 import { ProjectNode } from "./projectNode";
+import { WorkspaceNode } from "./workspaceNode";
+import { HierarchicalPackageNodeData } from "../java/hierarchicalPackageNodeData";
 
 export class NodeFactory {
-    public static createPackageRootNode(nodeData: INodeData, parent: DataNode, project: ProjectNode): PackageRootNode {
-        return Settings.isHierarchicalView() ?
-            new HierarchicalPackageRootNode(nodeData, parent, project) : new PackageRootNode(nodeData, parent, project);
+    /**
+     * Factory method to create explorer node.
+     * @param nodeData INodeData instance.
+     * @param parent parent of this node.
+     * @param project project node that this node belongs to.
+     * @param rootNode package root node that this node belongs to.
+     */
+    public static createNode(nodeData: INodeData, parent?: DataNode, project?: ProjectNode, rootNode?: DataNode): ExplorerNode | undefined {
+        const isHierarchicalView = Settings.isHierarchicalView();
+        try {
+            switch (nodeData.kind) {
+                case NodeKind.Workspace:
+                    return new WorkspaceNode(nodeData, parent);
+                case NodeKind.Project:
+                    return new ProjectNode(nodeData, parent);
+                case NodeKind.Container:
+                    if (!parent || !project) {
+                        throw new Error("Container node must have parent and project.");
+                    }
+
+                    return new ContainerNode(nodeData, parent, project);
+                case NodeKind.PackageRoot:
+                    if (!parent || !project) {
+                        throw new Error("Package root node must have parent and project.");
+                    }
+
+                    if (isHierarchicalView) {
+                        return new HierarchicalPackageRootNode(nodeData, parent, project);
+                    }
+                    return new PackageRootNode(nodeData, parent, project);
+                case NodeKind.Package:
+                    if (!parent || !project || !rootNode) {
+                        throw new Error("Package node must have parent, project and root.");
+                    }
+
+                    if (nodeData instanceof HierarchicalPackageNodeData) {
+                        return new HierarchicalPackageNode(nodeData, parent, project, rootNode);
+                    }
+                    return new PackageNode(nodeData, parent, project, rootNode);
+                case NodeKind.PrimaryType:
+                    if (nodeData.metaData && nodeData.metaData[PrimaryTypeNode.K_TYPE_KIND]) {
+                        if (!parent) {
+                            throw new Error("Primary type node must have parent.");
+                        }
+
+                        return new PrimaryTypeNode(nodeData, parent, rootNode);
+                    }
+                    return undefined;
+                case NodeKind.Folder:
+                    if (!parent || !project) {
+                        throw new Error("Folder node must have parent and project.");
+                    }
+
+                    return new FolderNode(nodeData, parent, project, rootNode);
+                case NodeKind.File:
+                    if (!parent) {
+                        throw new Error("Folder node must have parent.");
+                    }
+
+                    return new FileNode(nodeData, parent);
+                default:
+                    throw new Error(`Unsupported node kind: ${nodeData.kind}`);
+            }
+        } catch (error) {
+            sendError(new Error(`Unsupported node kind: ${nodeData.kind}`));
+            return undefined;
+        }
+        
     }
 }

--- a/src/views/packageNode.ts
+++ b/src/views/packageNode.ts
@@ -9,10 +9,8 @@ import { IPackageRootNodeData, PackageRootKind } from "../java/packageRootNodeDa
 import { isTest } from "../utility";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
-import { FileNode } from "./fileNode";
-import { FolderNode } from "./folderNode";
-import { PrimaryTypeNode } from "./PrimaryTypeNode";
 import { ProjectNode } from "./projectNode";
+import { NodeFactory } from "./nodeFactory";
 
 export class PackageNode extends DataNode {
     constructor(nodeData: INodeData, parent: DataNode, protected _project: ProjectNode, protected _rootNode: DataNode) {
@@ -34,22 +32,13 @@ export class PackageNode extends DataNode {
     }
 
     protected createChildNodeList(): ExplorerNode[] {
-        const result: ExplorerNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
-            this.sort();
             this.nodeData.children.forEach((nodeData) => {
-                if (nodeData.kind === NodeKind.File) {
-                    result.push(new FileNode(nodeData, this));
-                } else if (nodeData.kind === NodeKind.PrimaryType) {
-                    if (nodeData.metaData && nodeData.metaData[PrimaryTypeNode.K_TYPE_KIND]) {
-                        result.push(new PrimaryTypeNode(nodeData, this, this._rootNode));
-                    }
-                } else if (nodeData.kind === NodeKind.Folder) {
-                    result.push(new FolderNode(nodeData, this, this._project, this._rootNode));
-                }
+                result.push(NodeFactory.createNode(nodeData, this, this._project, this._rootNode));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     protected get iconPath(): ThemeIcon {

--- a/src/views/packageRootNode.ts
+++ b/src/views/packageRootNode.ts
@@ -11,11 +11,8 @@ import { isTest } from "../utility";
 import { ContainerNode } from "./containerNode";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
-import { FileNode } from "./fileNode";
-import { FolderNode } from "./folderNode";
-import { PackageNode } from "./packageNode";
-import { PrimaryTypeNode } from "./PrimaryTypeNode";
 import { ProjectNode } from "./projectNode";
+import { NodeFactory } from "./nodeFactory";
 
 export class PackageRootNode extends DataNode {
 
@@ -38,24 +35,13 @@ export class PackageRootNode extends DataNode {
     }
 
     protected createChildNodeList(): ExplorerNode[] {
-        const result: ExplorerNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
-            this.sort();
-            this.nodeData.children.forEach((data: INodeData) => {
-                if (data.kind === NodeKind.Package) {
-                    result.push(new PackageNode(data, this, this._project, this));
-                } else if (data.kind === NodeKind.File) {
-                    result.push(new FileNode(data, this));
-                } else if (data.kind === NodeKind.Folder) {
-                    result.push(new FolderNode(data, this, this._project, this));
-                } else if (data.kind === NodeKind.PrimaryType) {
-                    if (data.metaData && data.metaData[PrimaryTypeNode.K_TYPE_KIND]) {
-                        result.push(new PrimaryTypeNode(data, this, this));
-                    }
-                }
+            this.nodeData.children.forEach((nodeData) => {
+                result.push(NodeFactory.createNode(nodeData, this, this._project, this));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     protected get description(): string | boolean | undefined {

--- a/src/views/workspaceNode.ts
+++ b/src/views/workspaceNode.ts
@@ -7,7 +7,7 @@ import { Jdtls } from "../java/jdtls";
 import { INodeData } from "../java/nodeData";
 import { DataNode } from "./dataNode";
 import { ExplorerNode } from "./explorerNode";
-import { ProjectNode } from "./projectNode";
+import { NodeFactory } from "./nodeFactory";
 
 export class WorkspaceNode extends DataNode {
     constructor(nodeData: INodeData, parent?: DataNode) {
@@ -22,13 +22,13 @@ export class WorkspaceNode extends DataNode {
     }
 
     protected createChildNodeList(): ExplorerNode[] {
-        const result: ExplorerNode[] = [];
+        const result: (ExplorerNode | undefined)[] = [];
         if (this.nodeData.children && this.nodeData.children.length) {
             this.nodeData.children.forEach((nodeData) => {
-                result.push(new ProjectNode(nodeData, this));
+                result.push(NodeFactory.createNode(nodeData, this));
             });
         }
-        return result;
+        return result.filter(<T>(n?: T): n is T => Boolean(n));
     }
 
     protected get iconPath(): ThemeIcon {


### PR DESCRIPTION
- Use factory pattern to create nodes. This can remove a lot of duplicated codes.
- Redefine the `NodeKind` enum to better sort the nodes in explorer