### PR TITLE
fix: Apply 'files.exclude' to Java Projects explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Display non-Java files in Java Projects explorer. [#145](https://github.com/microsoft/vscode-java-dependency/issues/145)
 - Apply file decorators to project level. [#481](https://github.com/microsoft/vscode-java-dependency/issues/481)
 
+### Fixed
+- Apply `files.exclude` to Java Projects explorer. [#214](https://github.com/microsoft/vscode-java-dependency/issues/214)
+
 ## 0.21.2
 ### Fixed
 - Improve the output of exporting jar tasks. [#699](https://github.com/microsoft/vscode-java-dependency/issues/699)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,8 @@ export class Settings {
         context.subscriptions.push(workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
             if ((e.affectsConfiguration("java.dependency.syncWithFolderExplorer") && Settings.syncWithFolderExplorer()) ||
                     e.affectsConfiguration("java.dependency.showMembers") ||
-                    e.affectsConfiguration("java.dependency.packagePresentation")) {
+                    e.affectsConfiguration("java.dependency.packagePresentation") ||
+                    e.affectsConfiguration("files.exclude")) {
                 commands.executeCommand(Commands.VIEW_PACKAGE_INTERNAL_REFRESH);
             } else if (e.affectsConfiguration("java.dependency.autoRefresh")) {
                 syncHandler.updateFileWatcher(Settings.autoRefresh());

--- a/test/maven-suite/projectView.test.ts
+++ b/test/maven-suite/projectView.test.ts
@@ -223,4 +223,11 @@ suite("Maven Project View Tests", () => {
         assert.equal(mainClasses![0].name, "com.mycompany.app.App", "mainClasses[0]'s name should be com.mycompany.app.App");
     });
 
+    test("Can apply 'files.exclude'", async function() {
+        const explorer = DependencyExplorer.getInstance(contextManager.context);
+
+        const projectNode = (await explorer.dataProvider.getChildren())![0] as ProjectNode;
+        const projectChildren = await projectNode.getChildren();
+        assert.ok(!projectChildren.find((node: DataNode) => node.nodeData.name === ".hidden"));
+    });
 });

--- a/test/maven/.vscode/settings.json
+++ b/test/maven/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "java.server.launchMode": "Standard"
+    "java.server.launchMode": "Standard",
+    "files.exclude": {
+        "**/.hidden": true,
+    }
 }


### PR DESCRIPTION
fix #214 

gif:
![files-exclude](https://user-images.githubusercontent.com/6193897/230853488-b6b45401-d636-4611-b39f-51796b76875e.gif)

---

Different from #216, in this PR, the logic is controlled at client side, since this is a client related setting. Using `org.eclipse.core.resources.regexFilterMatcher` will modify the `.project` file which is not ideal - mess user's SCM.