### PR TITLE
Give more hints about the project import status

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/plugin.xml
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/plugin.xml
@@ -9,6 +9,7 @@
             <command id="java.resolvePath" />
             <command id="java.project.getMainClasses" />
             <command id="java.project.generateJar" />
+            <command id="java.project.checkImportStatus" />
         </delegateCommandHandler>
     </extension>
     <extension

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/CommandHandler.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/CommandHandler.java
@@ -35,6 +35,8 @@ public class CommandHandler implements IDelegateCommandHandler {
                     return ProjectCommand.getMainClasses(arguments, monitor);
                 case "java.project.generateJar":
                     return ProjectCommand.exportJar(arguments, monitor);
+                case "java.project.checkImportStatus":
+                    return ProjectCommand.checkImportStatus();
                 default:
                     break;
             }

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -29,6 +29,7 @@ import java.util.zip.ZipFile;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
@@ -280,6 +281,29 @@ public final class ProjectCommand {
         } catch (CoreException e) {
             return null;
         }
+    }
+
+    public static boolean checkImportStatus() {
+        IProject[] projects = ProjectUtils.getAllProjects();
+        for (IProject project : projects) {
+            if (ProjectsManager.DEFAULT_PROJECT_NAME.equals(project.getName())) {
+                continue;
+            }
+            try {
+                List<IMarker> markers = ResourceUtils.getErrorMarkers(project);
+                if (markers != null) {
+                    boolean hasError = markers.stream().anyMatch(m -> {
+                        return m.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR;
+                    });
+                    if (hasError) {
+                        return true;
+                    }
+                }
+            } catch (CoreException e) {
+                JdtlsExtActivator.log(e);
+            }
+        }
+        return false;
     }
 
     private static void reportExportJarMessage(String terminalId, int severity, String message) {

--- a/package.json
+++ b/package.json
@@ -426,12 +426,12 @@
         },
         {
           "command": "java.view.package.exportJar",
-          "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects",
+          "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects && !java:importFailed",
           "group": "navigation@20"
         },
         {
           "command": "java.project.build.workspace",
-          "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects",
+          "when": "view == javaProjectExplorer && java:serverMode == Standard && !java:noJavaProjects && !java:importFailed",
           "group": "navigation@30"
         },
         {
@@ -637,6 +637,11 @@
         "view": "javaProjectExplorer",
         "contents": "%viewsWelcome.workbench.installLanguageSupport%",
         "when": "java:projectManagerActivated && !java:languageSupportInstalled"
+      },
+      {
+        "view": "javaProjectExplorer",
+        "contents": "%viewsWelcome.workbench.importFailed%",
+        "when": "java:importFailed"
       }
     ],
     "taskDefinitions": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -44,7 +44,8 @@
   "taskDefinitions.java.project.build.path.exclude": "The path after '!' will be excluded from the paths to be built.",
   "taskDefinitions.java.project.build.isFullBuild": "Whether to execute a clean build or not.",
   "viewsWelcome.workbench.createNewJavaProject": "You can also [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:java.project.create)",
-  "viewsWelcome.workbench.noJavaProject": "No Java projects found in the current workspace. You can [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:java.project.create)",
+  "viewsWelcome.workbench.noJavaProject": "No Java projects found in the current workspace. You can [pen a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:java.project.create)",
+  "viewsWelcome.workbench.importFailed": "Oops, something went wrong when opening Java projects. Please use the following action for troubleshooting:\n[Open Problems View](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "To view the projects, you can import the projects into workspace.\n[Import Projects](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "The Java Projects explorer requires [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) to provide full features.\n[Install](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -45,6 +45,7 @@
   "taskDefinitions.java.project.build.isFullBuild": "是否要重新构建项目。",
   "viewsWelcome.workbench.createNewJavaProject": "您也可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:java.project.create)",
   "viewsWelcome.workbench.noJavaProject": "当前工作空间未发现 Java 项目，您可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:java.project.create)",
+  "viewsWelcome.workbench.importFailed": "加载 Java 项目时出现错误，请通过以下方式查看错误相关信息：\n[打开问题视图](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "要浏览项目信息，你可以将项目导入到工作空间中。\n[导入项目](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "Java 项目视图需要安装并激活 [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) 以提供完整的功能。\n[安装](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -45,6 +45,7 @@
   "taskDefinitions.java.project.build.isFullBuild": "是否要重新建置專案。",
   "viewsWelcome.workbench.createNewJavaProject": "您也可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:java.project.create)",
   "viewsWelcome.workbench.noJavaProject": "當前工作區未發現 Java 專案，您可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:java.project.create)",
+  "viewsWelcome.workbench.importFailed": "加載 Java 專案時出現錯誤，請通過以下方式查看錯誤相關信息：\n[打開問題視圖](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "若要檢視各專案，你可以將專案匯入到工作區中。\n[匯入專案](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "Java 專案視圖需要安裝並啟用 [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) 以提供完整的功能。\n[安裝](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -96,6 +96,8 @@ export namespace Commands {
 
     export const JAVA_UPDATE_DEPRECATED_TASK = "java.updateDeprecatedTask";
 
+    export const JAVA_PROJECT_CHECK_IMPORT_STATUS = "java.project.checkImportStatus";
+
     /**
      * Commands from Visual Studio Code
      */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export namespace Context {
     export const EXTENSION_ACTIVATED: string = "java:projectManagerActivated";
     export const LANGUAGE_SUPPORT_INSTALLED: string = "java:languageSupportInstalled";
     export const NO_JAVA_PROJECT: string = "java:noJavaProjects";
+    export const IMPORT_FAILED: string = "java:importFailed";
     export const WORKSPACE_CONTAINS_BUILD_FILES: string = "java:workspaceContainsBuildFiles";
     export const RELOAD_PROJECT_ACTIVE: string = "java:reloadProjectActive";
     export const SHOW_DEPRECATED_TASKS: string = "java:showDeprecatedTasks";

--- a/src/java/jdtls.ts
+++ b/src/java/jdtls.ts
@@ -64,6 +64,10 @@ export namespace Jdtls {
             mainClass, classpaths, destination, terminalId, token);
     }
 
+    export async function checkImportStatus(): Promise<boolean> {
+        return commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND, Commands.JAVA_PROJECT_CHECK_IMPORT_STATUS) || false;
+    }
+
     export enum CompileWorkspaceStatus {
         Failed = 0,
         Succeed = 1,

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -191,7 +191,14 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
                     this._rootItems = rootItems;
                 }
             }
-            contextManager.setContextValue(Context.NO_JAVA_PROJECT, _.isEmpty(rootItems));
+            if (_.isEmpty(rootItems)) {
+                const hasJavaError: boolean = await Jdtls.checkImportStatus();
+                if (hasJavaError) {
+                    contextManager.setContextValue(Context.IMPORT_FAILED, true);
+                } else {
+                    contextManager.setContextValue(Context.NO_JAVA_PROJECT, true);
+                }
+            }
             return rootItems;
         } finally {
             explorerLock.release();


### PR DESCRIPTION
- If there is no project available, and the workspace exists error markers, show the error message in the view.

![image](https://user-images.githubusercontent.com/6193897/231041656-747fb102-9734-471a-88a9-093687f2ce49.png)

fix #580 

Because the time when the diagnostics are available is not predicable, so the implementation does not directly check if there is error-level diagnostics in the collection. Instead, it directly checks if the workspace exists error markers.