### PR TITLE
fix: Show 'module-info.java' at source roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 0.22.0
 ### Added
 - Display non-Java files in Java Projects explorer. [#145](https://github.com/microsoft/vscode-java-dependency/issues/145)
-- Show non Java Projects in the Java Projects explorer. [#736](https://github.com/microsoft/vscode-java-dependency/issues/736)
+- Show non Java projects in the Java Projects explorer. [#736](https://github.com/microsoft/vscode-java-dependency/issues/736)
 - Support creating files and folders in Java Projects explorer. [#598](https://github.com/microsoft/vscode-java-dependency/issues/598)
 - Apply file decorators to project level. [#481](https://github.com/microsoft/vscode-java-dependency/issues/481)
 - Give more hints about the project import status. [#580](https://github.com/microsoft/vscode-java-dependency/issues/580)
 ### Fixed
 - Apply `files.exclude` to Java Projects explorer. [#214](https://github.com/microsoft/vscode-java-dependency/issues/214)
+- Empty packages will not appear sometimes. [#600](https://github.com/microsoft/vscode-java-dependency/issues/600)
+- Show `module-info.java` at source roots. [698](https://github.com/microsoft/vscode-java-dependency/issues/698)
 
 ## 0.21.2
 ### Fixed

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
@@ -540,9 +540,10 @@ public class PackageCommand {
 
         IModuleDescription moduleDescription = root.getModuleDescription();
         if (moduleDescription != null) {
-            IClassFile moduleInfo = moduleDescription.getClassFile();
-            if (moduleInfo != null) {
+            if (moduleDescription.getClassFile() != null) {
                 result.add(moduleDescription.getClassFile());
+            } else if (moduleDescription.getCompilationUnit() != null) {
+                result.add(moduleDescription.getCompilationUnit());
             }
         }
         return result;

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/JavaResourceVisitor.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/JavaResourceVisitor.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -55,6 +56,13 @@ public class JavaResourceVisitor implements ResourceVisitor {
     public void visit(IClassFile classFile) {
         PackageNode node = new PackageNode(classFile.getElementName(), null, NodeKind.FILE);
         node.setUri(JDTUtils.toUri(classFile));
+        this.nodes.add(node);
+    }
+
+    @Override
+    public void visit(ICompilationUnit compilationUnit) {
+        PackageNode node = new PackageNode(compilationUnit.getElementName(), null, NodeKind.FILE);
+        node.setUri(JDTUtils.toUri(compilationUnit));
         this.nodes.add(node);
     }
 

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -101,6 +102,8 @@ public class ResourceSet {
                 visitor.visit((IType) resource);
             } else if (resource instanceof IClassFile) {
                 visitor.visit((IClassFile) resource);
+            } else if (resource instanceof ICompilationUnit) {
+                visitor.visit((ICompilationUnit) resource);
             } else if (resource instanceof IFile) {
                 if (shouldVisit((IFile) resource)) {
                     visitor.visit((IFile) resource);

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceVisitor.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceVisitor.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -39,6 +40,8 @@ public interface ResourceVisitor {
     void visit(IType type);
 
     void visit(IClassFile classFile);
+
+    void visit(ICompilationUnit compilationUnit);
 
     void visit(IFile file);
 

--- a/test/maven-suite/projectView.test.ts
+++ b/test/maven-suite/projectView.test.ts
@@ -33,10 +33,13 @@ suite("Maven Project View Tests", () => {
         const mainPackage = projectChildren[0] as PackageRootNode;
         assert.equal(mainPackage.name, "src/main/java", "Package name should be \"src/main/java\"");
 
-        const primarySubPackages = await mainPackage.getChildren();
-        assert.equal(primarySubPackages.length, 1, "Number of primary subpackages should be 1");
-        const primarySubPackage = primarySubPackages[0] as PackageNode;
+        const mainSourceSetChildren = await mainPackage.getChildren();
+        assert.equal(mainSourceSetChildren.length, 2, "Number of primary subpackages should be 2");
+        const primarySubPackage = mainSourceSetChildren[0] as DataNode;
         assert.equal(primarySubPackage.name, "com.mycompany", "Name of primary subpackage should be \"com.mycompany\"");
+
+        const moduleInfo = mainSourceSetChildren[1] as DataNode;
+        assert.equal(moduleInfo.name, "module-info.java");
 
         const secondarySubPackages = await primarySubPackage.getChildren();
         assert.equal(secondarySubPackages.length, 2, "Number of secondary subpackages should be 1");
@@ -85,15 +88,23 @@ suite("Maven Project View Tests", () => {
         assert.equal(mavenDependency.name, "Maven Dependencies", "Container name should be \"Maven Dependencies\"");
 
         // validate package nodes
-        const mainSubPackages = await mainPackage.getChildren();
-        const testSubPackages = await testPackage.getChildren();
-        assert.equal(mainSubPackages.length, 2, "Number of main sub packages should be 2");
-        assert.equal(testSubPackages.length, 1, "Number of test sub packages should be 1");
-        const firstMainSubPackage = mainSubPackages[0] as PackageNode;
-        const secondMainSubPackage = mainSubPackages[1] as PackageNode;
-        const testSubPackage = testSubPackages[0] as PackageNode;
+        const mainSourceSetChildren = await mainPackage.getChildren();
+        assert.equal(mainSourceSetChildren.length, 3, "Number of main source set children should be 3");
+
+        const firstMainSubPackage = mainSourceSetChildren[0] as DataNode;
         assert.equal(firstMainSubPackage.name, "com.mycompany.app", "Name of first main subpackage should be \"com.mycompany.app\"");
+
+        const secondMainSubPackage = mainSourceSetChildren[1] as DataNode;
         assert.equal(secondMainSubPackage.name, "com.mycompany.app1", "Name of second main subpackage should be \"com.mycompany.app1\"");
+
+        const moduleInfo = mainSourceSetChildren[2] as DataNode;
+        assert.equal(moduleInfo.name, "module-info.java");
+
+        const testSourceSetChildren = await testPackage.getChildren();
+        assert.equal(testSourceSetChildren.length, 1, "Number of test sub packages should be 1");
+        const testSubPackage = testSourceSetChildren[0] as PackageNode;
+        
+        
         assert.equal(testSubPackage.name, "com.mycompany.app", "Name of test subpackage should be \"com.mycompany.app\"");
 
         // validate innermost layer nodes
@@ -195,9 +206,10 @@ suite("Maven Project View Tests", () => {
             path: mainPackage.nodeData.name,
             handlerIdentifier: mainPackage.nodeData.handlerIdentifier,
         });
-        assert.equal(packages?.length, 2, "packages' length should be 2");
-        assert.equal(packages![0].name, "com.mycompany.app", "package[0]'s name should be com.mycompany.app");
-        assert.equal(packages![1].name, "com.mycompany.app1", "package[1]'s name should be com.mycompany.app1");
+        assert.equal(packages?.length, 3, "packages' length should be 3");
+        assert.equal(packages![0].name, "com.mycompany.app");
+        assert.equal(packages![1].name, "com.mycompany.app1");
+        assert.equal(packages![2].name, "module-info.java");
     });
 
     test("Can execute command java.resolvePath correctly", async function() {

--- a/test/maven/pom.xml
+++ b/test/maven/pom.xml
@@ -7,6 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <name>my-app</name>
   <url>http://maven.apache.org</url>
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/test/maven/src/main/java/module-info.java
+++ b/test/maven/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module my.app {
+    exports com.mycompany.app1;
+    exports com.mycompany.app;
+}


### PR DESCRIPTION
fix #698 