### PR TITLE
fix: Better handling the import error hint

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/ProjectCommand.java
@@ -296,15 +296,15 @@ public final class ProjectCommand {
 
     public static boolean checkImportStatus() {
         IProject[] projects = ProjectUtils.getAllProjects();
-        boolean hasJavaProjectImported = false;
         boolean hasError = false;
         for (IProject project : projects) {
             if (ProjectsManager.DEFAULT_PROJECT_NAME.equals(project.getName())) {
                 continue;
             }
 
+            // if a Java project found, we think it as success import now.
             if (ProjectUtils.isJavaProject(project)) {
-                hasJavaProjectImported = true;
+                return false;
             }
 
             try {
@@ -318,8 +318,7 @@ public final class ProjectCommand {
             }
         }
 
-        // We think error happens if there is no java project imported and errors exist in workspace.
-        return hasError && (!hasJavaProjectImported);
+        return hasError;
     }
 
     private static void reportExportJarMessage(String terminalId, int severity, String message) {

--- a/src/views/dependencyDataProvider.ts
+++ b/src/views/dependencyDataProvider.ts
@@ -173,6 +173,12 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
                 return this._rootItems;
             }
 
+            const hasJavaError: boolean = await Jdtls.checkImportStatus();
+            if (hasJavaError) {
+                contextManager.setContextValue(Context.IMPORT_FAILED, true);
+                return [];
+            }
+
             const rootItems: ExplorerNode[] = [];
             const folders = workspace.workspaceFolders;
             if (folders && folders.length) {
@@ -192,12 +198,7 @@ export class DependencyDataProvider implements TreeDataProvider<ExplorerNode> {
                 }
             }
             if (_.isEmpty(rootItems)) {
-                const hasJavaError: boolean = await Jdtls.checkImportStatus();
-                if (hasJavaError) {
-                    contextManager.setContextValue(Context.IMPORT_FAILED, true);
-                } else {
-                    contextManager.setContextValue(Context.NO_JAVA_PROJECT, true);
-                }
+                contextManager.setContextValue(Context.NO_JAVA_PROJECT, true);
             }
             return rootItems;
         } finally {


### PR DESCRIPTION
Since we will now display non Java projects (#744), the logic to check import error(#740) needs to be changed.

Now before we try to get the project nodes, we will first check if there is potential import errors. The extension will consider there is an import error if:

- No Java Project is imported into workspace except for default project
- There is at least one error marker in workspace.