### PR TITLE
chore: Update VS Code engine version to 1.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.18.11",
         "@types/semver": "^7.3.13",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.77.0",
         "@vscode/test-electron": "^2.2.2",
         "copy-webpack-plugin": "^11.0.0",
         "glob": "^7.2.3",
@@ -39,7 +39,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.77.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -449,9 +449,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -5523,9 +5523,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "explorer"
   ],
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.77.0"
   },
   "repository": {
     "type": "git",
@@ -872,7 +872,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.18.11",
     "@types/semver": "^7.3.13",
-    "@types/vscode": "1.75.0",
+    "@types/vscode": "1.77.0",
     "@vscode/test-electron": "^2.2.2",
     "copy-webpack-plugin": "^11.0.0",
     "glob": "^7.2.3",


### PR DESCRIPTION
Since we are now using new when clause gramma, update the required VS Code version to 1.77.0 to avoid unexpected feature failure.

https://github.com/microsoft/vscode/issues/175540#issuecomment-1494256462