### PR TITLE
feat: Support create Graal Cloud Native projects.

### DIFF
--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -96,6 +96,7 @@ enum ProjectType {
     MicroProfile = "MicroProfile",
     JavaFX = "JavaFX",
     Micronaut = "Micronaut",
+    GCN = "GCN",
 }
 
 async function ensureExtension(typeName: string, metaData: IProjectTypeMetadata): Promise<boolean> {
@@ -258,6 +259,15 @@ const projectTypes: IProjectType[] = [
             extensionId: "oracle-labs-graalvm.micronaut",
             extensionName: "GraalVM Tools for Micronaut",
             createCommandId: "extension.micronaut.createProject",
+        },
+    },
+    {
+        displayName: "Graal Cloud Native",
+        metadata: {
+            type: ProjectType.GCN,
+            extensionId: "oracle-labs-graalvm.gcn",
+            extensionName: "Graal Cloud Native Tools",
+            createCommandId: "gcn.createGcnProject",
         },
     },
 ];


### PR DESCRIPTION
Adding support for creating Graal Cloud Native (GCN) projects. GCN projects can be created by calling the 'gcn.createGcnProject' command provided by the [Graal Cloud Native Tools](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.gcn) extension. For more information on GCN, see [https://www.graal.cloud](https://www.graal.cloud).