### PR TITLE
Contribute 'New Java Project...' command to File/NewFile and File Explorer menus

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.target/com.microsoft.jdtls.ext.tp.target
+++ b/jdtls.ext/com.microsoft.jdtls.ext.target/com.microsoft.jdtls.ext.tp.target
@@ -15,7 +15,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2023-12/202311171000/"/>
+            <repository location="https://download.eclipse.org/releases/2023-12"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^16.18.11",
         "@types/semver": "^7.3.13",
         "@types/vscode": "1.77.0",
-        "@vscode/test-electron": "^2.2.2",
+        "@vscode/test-electron": "^2.3.8",
         "copy-webpack-plugin": "^11.0.0",
         "glob": "^7.2.3",
         "mocha": "^9.2.2",
@@ -453,15 +453,15 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=16"
@@ -5691,15 +5691,15 @@
       }
     },
     "@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       }
     },
     "@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -1000,7 +1000,7 @@
     "@types/node": "^16.18.11",
     "@types/semver": "^7.3.13",
     "@types/vscode": "1.77.0",
-    "@vscode/test-electron": "^2.2.2",
+    "@vscode/test-electron": "^2.3.8",
     "copy-webpack-plugin": "^11.0.0",
     "glob": "^7.2.3",
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
         "icon": "$(add)"
       },
       {
+        "command": "_java.project.create.from.fileexplorer.menu",
+        "title": "%contributes.commands.java.project.new%",
+        "category": "Java",
+        "icon": "$(add)"
+      },
+      {
         "command": "_java.project.create.from.fileexplorer.welcome",
         "title": "%contributes.commands.java.project.create%",
         "category": "Java",
@@ -521,6 +527,10 @@
           "when": "false"
         },
         {
+          "command": "_java.project.create.from.fileexplorer.menu",
+          "when": "false"
+        },
+        {
           "command": "_java.project.create.from.fileexplorer.welcome",
           "when": "false"
         },
@@ -543,6 +553,11 @@
           "command": "java.view.package.revealInProjectExplorer",
           "when": "resourceExtname == .java && java:serverMode == Standard",
           "group": "navigation@100"
+        },
+        {
+          "command": "_java.project.create.from.fileexplorer.menu",
+          "when": "explorerResourceIsFolder",
+          "group": "navigation@10"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -56,6 +56,30 @@
         "icon": "$(add)"
       },
       {
+        "command": "_java.project.create.from.menus.file",
+        "title": "%contributes.commands.java.project.new%",
+        "category": "Java",
+        "icon": "$(add)"
+      },
+      {
+        "command": "_java.project.create.from.fileexplorer.welcome",
+        "title": "%contributes.commands.java.project.create%",
+        "category": "Java",
+        "icon": "$(add)"
+      },
+      {
+        "command": "_java.project.create.from.javaprojectexplorer.welcome",
+        "title": "%contributes.commands.java.project.create%",
+        "category": "Java",
+        "icon": "$(add)"
+      },
+      {
+        "command": "_java.project.create.from.javaprojectexplorer",
+        "title": "%contributes.commands.java.project.create%",
+        "category": "Java",
+        "icon": "$(add)"
+      },
+      {
         "command": "java.project.addLibraries",
         "title": "%contributes.commands.java.project.addLibraries%",
         "category": "Java",
@@ -358,6 +382,9 @@
       "file/newFile": [
         {
           "command": "java.view.menus.file.newJavaClass"
+        },
+        {
+          "command": "_java.project.create.from.menus.file"
         }
       ],
       "commandPalette": [
@@ -488,6 +515,22 @@
         {
           "command": "java.view.package.revealInProjectExplorer",
           "when": "false"
+        },
+        {
+          "command": "_java.project.create.from.menus.file",
+          "when": "false"
+        },
+        {
+          "command": "_java.project.create.from.fileexplorer.welcome",
+          "when": "false"
+        },
+        {
+          "command": "_java.project.create.from.javaprojectexplorer.welcome",
+          "when": "false"
+        },
+        {
+          "command": "_java.project.create.from.javaprojectexplorer",
+          "when": "false"
         }
       ],
       "explorer/context": [
@@ -523,7 +566,7 @@
       ],
       "view/title": [
         {
-          "command": "java.project.create",
+          "command": "_java.project.create.from.javaprojectexplorer",
           "when": "view == javaProjectExplorer",
           "group": "navigation@10"
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
   "description": "Manage Java projects in Visual Studio Code",
   "contributes.commands.java.project.create": "Create Java Project...",
+  "contributes.commands.java.project.new": "New Java Project...",
   "contributes.commands.java.project.addLibraries": "Add Jar Libraries to Project Classpath...",
   "contributes.commands.java.project.addLibraryFolders": "Add Library Folders to Project Classpath...",
   "contributes.commands.java.project.removeLibrary": "Remove from Project Classpath",
@@ -56,8 +57,8 @@
   "taskDefinitions.java.project.build.path.workspace": "All the projects in workspace.",
   "taskDefinitions.java.project.build.path.exclude": "The path after '!' will be excluded from the paths to be built.",
   "taskDefinitions.java.project.build.isFullBuild": "Whether to execute a clean build or not.",
-  "viewsWelcome.workbench.createNewJavaProject": "You can also [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:java.project.create)",
-  "viewsWelcome.workbench.noJavaProject": "No Java projects found in the current workspace. You can [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:java.project.create)",
+  "viewsWelcome.workbench.createNewJavaProject": "You can also [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:_java.project.create.from.fileexplorer.welcome)",
+  "viewsWelcome.workbench.noJavaProject": "No Java projects found in the current workspace. You can [open a Java project folder](command:_java.project.open), or create a new Java project by clicking the button below.\n[Create Java Project](command:_java.project.create.from.javaprojectexplorer.welcome)",
   "viewsWelcome.workbench.importFailed": "Oops, something went wrong when opening Java projects. Please use the following action for troubleshooting:\n[Open Problems View](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "To view the projects, you can import the projects into workspace.\n[Import Projects](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "The Java Projects explorer requires [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) to provide full features.\n[Install](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,6 +1,7 @@
 {
   "description": "在 Visual Studio Code 中管理 Java 项目",
   "contributes.commands.java.project.create": "创建 Java 项目...",
+  "contributes.commands.java.project.new": "创建 Java 项目...",
   "contributes.commands.java.project.addLibraries": "添加 Jar 文件至项目 Classpath...",
   "contributes.commands.java.project.addLibraryFolders": "添加文件夹至项目 Classpath...",
   "contributes.commands.java.project.removeLibrary": "从项目 Classpath 中移除",
@@ -56,8 +57,8 @@
   "taskDefinitions.java.project.build.path.workspace": "工作空间中的所有项目。",
   "taskDefinitions.java.project.build.path.exclude": "'!' 后的路径将会从待构建项目路径中移除。",
   "taskDefinitions.java.project.build.isFullBuild": "是否要重新构建项目。",
-  "viewsWelcome.workbench.createNewJavaProject": "您也可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:java.project.create)",
-  "viewsWelcome.workbench.noJavaProject": "当前工作空间未发现 Java 项目，您可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:java.project.create)",
+  "viewsWelcome.workbench.createNewJavaProject": "您也可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:_java.project.create.from.fileexplorer.welcome)",
+  "viewsWelcome.workbench.noJavaProject": "当前工作空间未发现 Java 项目，您可以[打开一个 Java 项目目录](command:_java.project.open)，或点击下方按钮创建一个新的 Java 项目。\n[创建 Java 项目](command:_java.project.create.from.javaprojectexplorer.welcome)",
   "viewsWelcome.workbench.importFailed": "加载 Java 项目时出现错误，请通过以下方式查看错误相关信息：\n[打开问题视图](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "要浏览项目信息，你可以将项目导入到工作空间中。\n[导入项目](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "Java 项目视图需要安装并激活 [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) 以提供完整的功能。\n[安装](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -1,6 +1,7 @@
 {
   "description": "在 Visual Studio Code 中管理 Java 專案",
   "contributes.commands.java.project.create": "建立 Java 專案...",
+  "contributes.commands.java.project.new": "建立 Java 專案...",
   "contributes.commands.java.project.addLibraries": "新增 Jar 檔案至專案 Classpath...",
   "contributes.commands.java.project.addLibraryFolders": "新增資料夾至專案 Classpath...",
   "contributes.commands.java.project.removeLibrary": "從專案 Classpath 中移除",
@@ -48,8 +49,8 @@
   "taskDefinitions.java.project.build.path.workspace": "工作區中的所有專案。",
   "taskDefinitions.java.project.build.path.exclude": "'!' 後的路徑將會從待建置專案路徑中移除。",
   "taskDefinitions.java.project.build.isFullBuild": "是否要重新建置專案。",
-  "viewsWelcome.workbench.createNewJavaProject": "您也可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:java.project.create)",
-  "viewsWelcome.workbench.noJavaProject": "當前工作區未發現 Java 專案，您可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:java.project.create)",
+  "viewsWelcome.workbench.createNewJavaProject": "您也可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:_java.project.create.from.fileexplorer.welcome)",
+  "viewsWelcome.workbench.noJavaProject": "當前工作區未發現 Java 專案，您可以[開啟一個 Java 專案目錄](command:_java.project.open)，或點擊下方按鈕建立一個新的 Java 專案。\n[建立 Java 專案](command:_java.project.create.from.javaprojectexplorer.welcome)",
   "viewsWelcome.workbench.importFailed": "加載 Java 專案時出現錯誤，請通過以下方式查看錯誤相關信息：\n[打開問題視圖](command:workbench.panel.markers.view.focus)",
   "viewsWelcome.workbench.inLightWeightMode": "若要檢視各專案，你可以將專案匯入到工作區中。\n[匯入專案](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
   "viewsWelcome.workbench.installLanguageSupport": "Java 專案視圖需要安裝並啟用 [Extension Pack for Java](command:extension.open?%5B%22vscjava.vscode-java-pack%22%5D) 以提供完整的功能。\n[安裝](command:java.project.installExtension?%5B%22vscjava.vscode-java-pack%22%5D)"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -74,6 +74,8 @@ export namespace Commands {
 
     export const JAVA_PROJECT_CREATE_FROM_MENUS_FILE = "_java.project.create.from.menus.file";
 
+    export const JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_MENU = "_java.project.create.from.fileexplorer.menu";
+
     export const JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_WELCOME = "_java.project.create.from.fileexplorer.welcome";
 
     export const JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER_WELCOME = "_java.project.create.from.javaprojectexplorer.welcome";

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -72,6 +72,14 @@ export namespace Commands {
 
     export const JAVA_PROJECT_CREATE = "java.project.create";
 
+    export const JAVA_PROJECT_CREATE_FROM_MENUS_FILE = "_java.project.create.from.menus.file";
+
+    export const JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_WELCOME = "_java.project.create.from.fileexplorer.welcome";
+
+    export const JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER_WELCOME = "_java.project.create.from.javaprojectexplorer.welcome";
+
+    export const JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER = "_java.project.create.from.javaprojectexplorer";
+
     export const JAVA_PROJECT_ADD_LIBRARIES = "java.project.addLibraries";
 
     export const JAVA_PROJECT_ADD_LIBRARY_FOLDERS = "java.project.addLibraryFolders";

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -18,6 +18,7 @@ export class ProjectController implements Disposable {
         this.disposable = Disposable.from(
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE, () => this.createJavaProject("command")),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_MENUS_FILE, () => this.createJavaProject("menus.file")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_MENU, () => this.createJavaProject("fileexplorer.menu")),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_WELCOME, () => this.createJavaProject("fileexplorer.welcome")),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER_WELCOME, () => this.createJavaProject("javaprojectexplorer.welcome")),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER, () => this.createJavaProject("javaprojectexplorer")),

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -17,11 +17,16 @@ export class ProjectController implements Disposable {
     public constructor(public readonly context: ExtensionContext) {
         this.disposable = Disposable.from(
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE, () => this.createJavaProject("command")),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_MENUS_FILE, () => this.createJavaProject("menus.file")),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_MENU, () => this.createJavaProject("fileexplorer.menu")),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_WELCOME, () => this.createJavaProject("fileexplorer.welcome")),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER_WELCOME, () => this.createJavaProject("javaprojectexplorer.welcome")),
-            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER, () => this.createJavaProject("javaprojectexplorer")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_MENUS_FILE,
+                () => this.createJavaProject("menus.file")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_MENU,
+                () => this.createJavaProject("fileexplorer.menu")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_FILEEXPLORER_WELCOME,
+                () => this.createJavaProject("fileexplorer.welcome")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER_WELCOME,
+                () => this.createJavaProject("javaprojectexplorer.welcome")),
+            instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_CREATE_FROM_JAVAPROJECTEXPLORER,
+                () => this.createJavaProject("javaprojectexplorer")),
             instrumentOperationAsVsCodeCommand(Commands.JAVA_PROJECT_OPEN, () => this.openJavaProject()),
             instrumentOperationAsVsCodeCommand(Commands.INSTALL_EXTENSION, (extensionId: string) => {
                 commands.executeCommand("workbench.extensions.installExtension", extensionId);

--- a/test/ui/command.test.ts
+++ b/test/ui/command.test.ts
@@ -59,9 +59,6 @@ describe("Command Tests", function() {
             try {
                 const serverStatus = await statusBar.findElement(By.xpath('//*[@id="redhat.java.java.serverStatus"]'));
                 await serverStatus.findElement(By.xpath('//a[contains(@class, "statusbar-item-label")]//span[contains(@class, "codicon-thumbsup")]'));
-                // const languageStatus = await statusBar.findElement(By.xpath('//*[@id="status.languageStatus"]'));
-                // await languageStatus.click();
-                // await languageStatus.findElement(By.xpath(`//div[contains(@id, 'context-view')]//div[contains(@class, 'hover-language-status')]//span[contains(@class, 'codicon-thumbsup')]`));
                 break;
             } catch (e) {
                 await sleep(100);

--- a/test/ui/command.test.ts
+++ b/test/ui/command.test.ts
@@ -6,9 +6,8 @@ import * as fse from "fs-extra";
 import { platform, tmpdir } from "os";
 import * as path from "path";
 import * as seleniumWebdriver from "selenium-webdriver";
-import { ActivityBar, By,   InputBox, ModalDialog, SideBarView, TextEditor, TreeItem, VSBrowser, ViewSection, Workbench } from "vscode-extension-tester";
+import { ActivityBar, By, InputBox, ModalDialog, SideBarView, StatusBar, TextEditor, TreeItem, VSBrowser, ViewSection, Workbench } from "vscode-extension-tester";
 import { sleep } from "../util";
-import { extensions } from "vscode";
 
 // tslint:disable: only-arrow-functions
 const newProjectName = "helloworld";
@@ -49,13 +48,25 @@ describe("Command Tests", function() {
     }
 
     async function waitForLanguageServerReady() {
-        const extension = extensions.getExtension("redhat.java");
-        if (!extension) {
-            throw new Error(`Extension "redhat.java" is not installed.`);
+        const statusBar = new StatusBar();
+        while (true) {
+            const language = await statusBar.getCurrentLanguage();
+            if (language === 'Java') {
+                break;
+            }
         }
-
-        const api = await extension.activate();
-        await api?.serverReady();
+        while (true) {
+            try {
+                const serverStatus = await statusBar.findElement(By.xpath('//*[@id="redhat.java.java.serverStatus"]'));
+                await serverStatus.findElement(By.xpath('//a[contains(@class, "statusbar-item-label")]//span[contains(@class, "codicon-thumbsup")]'));
+                // const languageStatus = await statusBar.findElement(By.xpath('//*[@id="status.languageStatus"]'));
+                // await languageStatus.click();
+                // await languageStatus.findElement(By.xpath(`//div[contains(@id, 'context-view')]//div[contains(@class, 'hover-language-status')]//span[contains(@class, 'codicon-thumbsup')]`));
+                break;
+            } catch (e) {
+                await sleep(100);
+            }
+        }
     }
 
     before(async function() {

--- a/test/ui/command.test.ts
+++ b/test/ui/command.test.ts
@@ -6,8 +6,9 @@ import * as fse from "fs-extra";
 import { platform, tmpdir } from "os";
 import * as path from "path";
 import * as seleniumWebdriver from "selenium-webdriver";
-import { ActivityBar, By,   InputBox, ModalDialog, SideBarView, StatusBar, TextEditor, TreeItem, VSBrowser, ViewSection, Workbench } from "vscode-extension-tester";
+import { ActivityBar, By,   InputBox, ModalDialog, SideBarView, TextEditor, TreeItem, VSBrowser, ViewSection, Workbench } from "vscode-extension-tester";
 import { sleep } from "../util";
+import { extensions } from "vscode";
 
 // tslint:disable: only-arrow-functions
 const newProjectName = "helloworld";
@@ -48,23 +49,13 @@ describe("Command Tests", function() {
     }
 
     async function waitForLanguageServerReady() {
-        const statusBar = new StatusBar();
-        while (true) {
-            const language = await statusBar.getCurrentLanguage();
-            if (language === 'Java') {
-                break;
-            }
+        const extension = extensions.getExtension("redhat.java");
+        if (!extension) {
+            throw new Error(`Extension "redhat.java" is not installed.`);
         }
-        while (true) {
-            try {
-                const languageStatus = await statusBar.findElement(By.xpath('//*[@id="status.languageStatus"]'));
-                await languageStatus.click();
-                await languageStatus.findElement(By.xpath(`//div[contains(@class, 'context-view')]//div[contains(@class, 'hover-language-status')]//span[contains(@class, 'codicon-thumbsup')]`));
-                break;
-            } catch (e) {
-                await sleep(100);
-            }
-        }
+
+        const api = await extension.activate();
+        await api?.serverReady();
     }
 
     before(async function() {


### PR DESCRIPTION
- Record the UI entry that triggers the "new java project" command.
- Contribute "New Java Project..." command to the top "**File -> New File...**" menus.
![image](https://github.com/microsoft/vscode-java-dependency/assets/14052197/c3d20ba2-6ed4-4a7c-9a6d-ad7b3230cbda)

- Contribute "New Java Project..." command to the context menu of File Explorer.
![image](https://github.com/microsoft/vscode-java-dependency/assets/14052197/89084961-3b8e-4458-bd22-9bce8bd91021)