### PR TITLE
Add 'New Java File' menu to file explorer & adjust the existing file explorer menu order

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -70,7 +70,7 @@ extends:
               - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
                 displayName: ESRP CodeSigning
                 inputs:
-                  ConnectedServiceName: vscjavaci_codesign
+                  ConnectedServiceName: vscjavaci_esrp_codesign
                   FolderPath: server
                   Pattern: com.microsoft.jdtls.ext.*.jar
                   signConfigType: inlineSignParams

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -65,7 +65,7 @@ extends:
               - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
                 displayName: ESRP CodeSigning
                 inputs:
-                  ConnectedServiceName: vscjavaci_codesign
+                  ConnectedServiceName: vscjavaci_esrp_codesign
                   FolderPath: server
                   Pattern: com.microsoft.jdtls.ext.*.jar
                   signConfigType: inlineSignParams

--- a/package.json
+++ b/package.json
@@ -547,17 +547,22 @@
         {
           "command": "java.view.package.revealInProjectExplorer",
           "when": "resourceFilename =~ /(.*\\.gradle)|(.*\\.gradle\\.kts)|(pom\\.xml)$/ && java:serverMode == Standard",
-          "group": "navigation@100"
+          "group": "1_javaactions"
         },
         {
           "command": "java.view.package.revealInProjectExplorer",
           "when": "resourceExtname == .java && java:serverMode == Standard",
-          "group": "navigation@100"
+          "group": "1_javaactions"
         },
         {
           "command": "_java.project.create.from.fileexplorer.menu",
           "when": "explorerResourceIsFolder",
-          "group": "navigation@10"
+          "group": "1_javaactions"
+        },
+        {
+          "submenu": "javaProject.newJavaFile",
+          "when": "explorerResourceIsFolder",
+          "group": "1_javaactions"
         }
       ],
       "editor/title": [
@@ -791,6 +796,38 @@
           "group": "new2@40",
           "when": "view == javaProjectExplorer && (viewItem =~ /java:(file|folder|project)/ || viewItem =~ /java:(packageRoot)(?=.*?\\b\\+resource\\b)/)"
         }
+      ],
+      "javaProject.newJavaFile": [
+        {
+          "command": "java.view.package.newJavaClass",
+          "group": "new@10",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "java.view.package.newJavaInterface",
+          "group": "new@20",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "java.view.package.newJavaEnum",
+          "group": "new@30",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "java.view.package.newJavaRecord",
+          "group": "new@40",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "java.view.package.newJavaAnnotation",
+          "group": "new@50",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "java.view.package.newJavaAbstractClass",
+          "group": "new@60",
+          "when": "explorerResourceIsFolder"
+        }
       ]
     },
     "submenus": [
@@ -805,6 +842,10 @@
       {
         "id": "javaProject.new",
         "label": "%contributes.submenus.javaProject.new%"
+      },
+      {
+        "id": "javaProject.newJavaFile",
+        "label": "%contributes.commands.java.view.menus.file.newJavaClass%"
       }
     ],
     "views": {

--- a/src/views/dependencyExplorer.ts
+++ b/src/views/dependencyExplorer.ts
@@ -116,22 +116,22 @@ export class DependencyExplorer implements Disposable {
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW, async (node: DataNode) => {
                 newResource(node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_CLASS, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.CLASS, node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_INTERFACE, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_INTERFACE, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.INTERFACE, node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ENUM, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ENUM, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.ENUM, node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_RECORD, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_RECORD, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.RECORD, node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ANNOTATION, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ANNOTATION, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.ANNOTATION, node);
             }),
-            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ABSTRACT_CLASS, async (node?: DataNode) => {
+            instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_JAVA_ABSTRACT_CLASS, async (node?: DataNode | Uri) => {
                 newJavaFileWithSpecificType(JavaType.ABSTRACT_CLASS, node);
             }),
             instrumentOperationAsVsCodeCommand(Commands.VIEW_PACKAGE_NEW_FILE, async (node: DataNode) => {


### PR DESCRIPTION
- Add 'New Java File' menu to file explorer
- Put the existing menus such as 'Reveal in Java Project Explorer', 'New Java Project...' into the same category as other Java context menus.

![image](https://github.com/microsoft/vscode-java-dependency/assets/14052197/00336afc-e4d7-41ab-be52-2d6d9e88b5bf)
