### PR TITLE
fix: Referenced Libraries container should be immutable for build tool projects

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/PackageCommand.java
@@ -303,10 +303,8 @@ public class PackageCommand {
         List<PackageNode> result = visitor.getNodes();
 
         // Invisible project will always have the referenced libraries entry
-        if (!ProjectUtils.isVisibleProject(project)) {
+        if (!ProjectUtils.isVisibleProject(project) || hasReferencedLibraries) {
             result.add(PackageNode.REFERENCED_LIBRARIES_CONTAINER);
-        } else if (hasReferencedLibraries) {
-            result.add(PackageNode.IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER);
         }
         return result;
     }
@@ -589,7 +587,7 @@ public class PackageCommand {
             }
 
             // This must be an invisible project.
-            // There might be more than one way to access it, but all containers should link to the same project. 
+            // There might be more than one way to access it, but all containers should link to the same project.
             return containers[0].getProject();
         }
     }

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/model/PackageNode.java
@@ -69,13 +69,9 @@ public class PackageNode {
 
     public static final String REFERENCED_LIBRARIES_PATH = "REFERENCED_LIBRARIES_PATH";
     private static final String REFERENCED_LIBRARIES_CONTAINER_NAME = "Referenced Libraries";
-    private static final String IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER_NAME = "Referenced Libraries (Read-only)";
     public static final ContainerNode REFERENCED_LIBRARIES_CONTAINER = new ContainerNode(
             REFERENCED_LIBRARIES_CONTAINER_NAME, REFERENCED_LIBRARIES_PATH,
             NodeKind.CONTAINER, IClasspathEntry.CPE_CONTAINER);
-    public static final ContainerNode IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER = new ContainerNode(
-            IMMUTABLE_REFERENCED_LIBRARIES_CONTAINER_NAME,
-            REFERENCED_LIBRARIES_PATH, NodeKind.CONTAINER, IClasspathEntry.CPE_CONTAINER);
 
     /**
      * Nature Id for the IProject.

--- a/src/views/containerNode.ts
+++ b/src/views/containerNode.ts
@@ -27,7 +27,8 @@ export class ContainerNode extends DataNode {
             return ContainerType.Maven;
         } else if (containerPath.startsWith(ContainerPath.Gradle)) {
             return ContainerType.Gradle;
-        } else if (containerPath.startsWith(ContainerPath.ReferencedLibrary)) {
+        } else if (containerPath.startsWith(ContainerPath.ReferencedLibrary) && this._project.isUnmanagedFolder()) {
+            // currently, we only support editing referenced libraries in unmanaged folders
             return ContainerType.ReferencedLibrary;
         }
         return ContainerType.Unknown;

--- a/src/views/packageRootNode.ts
+++ b/src/views/packageRootNode.ts
@@ -59,7 +59,8 @@ export class PackageRootNode extends DataNode {
         if (data.entryKind === PackageRootKind.K_BINARY) {
             contextValue = Explorer.ContextValueType.Jar;
             const parent = <ContainerNode>this.getParent();
-            if (parent.path?.startsWith("REFERENCED_LIBRARIES_PATH")) {
+            // currently, we only support editing referenced libraries in unmanaged folders
+            if (parent.path?.startsWith("REFERENCED_LIBRARIES_PATH") && this._project.isUnmanagedFolder()) {
                 contextValue += "+referencedLibrary";
             }
             return contextValue;

--- a/test/suite/contextValue.test.ts
+++ b/test/suite/contextValue.test.ts
@@ -182,7 +182,7 @@ const referencedLibrariesContainer: ContainerNode = new ContainerNode({
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.Container,
     path: "REFERENCED_LIBRARIES_PATH",
-}, mavenProject, mavenProject);
+}, mavenProject, unmanagedFolder);
 
 const sourceRoot: PackageRootNode = new PackageRootNode({
     name: "src/main/java",
@@ -220,7 +220,7 @@ const referencedLibraryJar: PackageRootNode = new PackageRootNode({
     uri: Uri.file(__dirname).toString(),
     kind: NodeKind.PackageRoot,
     entryKind: PackageRootKind.K_BINARY,
-} as INodeData, referencedLibrariesContainer, mavenProject);
+} as INodeData, referencedLibrariesContainer, unmanagedFolder);
 
 const sourcePackage: PackageNode = new PackageNode({
     name: "com.microsoft.java",


### PR DESCRIPTION
The referenced libraries should only be editable for unmanaged folders in the explorer.