### PR TITLE
Micronaut® Launch extension renamed.

### DIFF
--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -270,7 +270,7 @@ const projectTypes: IProjectType[] = [
         metadata: {
             type: ProjectType.Micronaut,
             extensionId: "oracle-labs-graalvm.micronaut",
-            extensionName: "Micronaut® Launch",
+            extensionName: "Launch for Micronaut® framework",
             createCommandId: "extension.micronaut.createProject",
         },
     },


### PR DESCRIPTION
`Micronaut® Launch` extension recently renamed to `Launch for Micronaut® framework`.