### PR TITLE
ci: jdk compile support jdk 24

### DIFF
--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -7,7 +7,19 @@ const path = require('path');
 
 const server_dir = path.resolve('jdtls.ext');
 
-cp.execSync(mvnw()+ ' clean package', {cwd:server_dir, stdio:[0,1,2]} );
+// Set JVM options to increase XML entity size limits
+const jvmOptions = [
+    '-Djdk.xml.maxGeneralEntitySizeLimit=0',
+    '-Djdk.xml.totalEntitySizeLimit=0',
+    '-Djdk.xml.maxElementDepth=0'
+].join(' ');
+
+// Set MAVEN_OPTS environment variable with JVM options
+const env = { ...process.env };
+env.MAVEN_OPTS = (env.MAVEN_OPTS || '') + ' ' + jvmOptions;
+
+const mvnCommand = `${mvnw()} clean package`;
+cp.execSync(mvnCommand, {cwd:server_dir, stdio:[0,1,2], env: env} );
 copy(path.join(server_dir, 'com.microsoft.jdtls.ext.core/target'), path.resolve('server'), (file) => {
     return /^com.microsoft.jdtls.ext.core.*.jar$/.test(file);
 });


### PR DESCRIPTION
while run `npm run build-server` with JDK 24, meeting such error
`JAXP00010003: The length of entity "[xml]" is "100,001" that exceeds the "100,000" limit set by "jdk.xml.maxGeneralEntitySizeLimit".`

JDK 24 contains changes to JAXP limits, see: https://bugs.openjdk.org/browse/JDK-8343022

update the build-sever script to build success with SDK 24+
