### PR TITLE
Add option to reveal selected path in VS Code Explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "vscode-tas-client": "^0.1.75"
       },
       "devDependencies": {
+        "@playwright/test": "^1.50.0",
         "@types/fs-extra": "^9.0.13",
         "@types/glob": "^7.2.0",
         "@types/lodash": "^4.14.191",
@@ -912,6 +913,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@redhat-developer/locators": {
@@ -3673,6 +3690,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5827,6 +5859,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -9269,6 +9333,15 @@
       "dev": true,
       "optional": true
     },
+    "@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.59.1"
+      }
+    },
     "@redhat-developer/locators": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.20.0.tgz",
@@ -11223,6 +11296,13 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -12710,6 +12790,22 @@
           }
         }
       }
+    },
+    "playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.59.1"
+      }
+    },
+    "playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true
     },
     "pluralize": {
       "version": "8.0.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import { commands } from "vscode";
+import * as vscode from 'vscode';
+
 /**
  * Commonly used commands
  */
@@ -29,8 +31,6 @@ export namespace Commands {
     export const VIEW_PACKAGE_INTERNAL_ADD_PROJECTS = "_java.view.package.internal.addProjects";
 
     export const VIEW_PACKAGE_OUTLINE = "java.view.package.outline";
-
-    export const VIEW_PACKAGE_REVEAL_FILE_OS = "java.view.package.revealFileInOS";
 
     export const VIEW_PACKAGE_COPY_FILE_PATH = "java.view.package.copyFilePath";
 
@@ -67,6 +67,8 @@ export namespace Commands {
     export const VIEW_PACKAGE_DELETE_FILE_PERMANENTLY = "java.view.package.deleteFilePermanently";
 
     export const VIEW_PACKAGE_REVEAL_IN_PROJECT_EXPLORER = "java.view.package.revealInProjectExplorer";
+    
+    export const VIEW_PACKAGE_REVEAL_FILE_VSCODE = 'java.view.package.revealFileInVSCode';
 
     export const VIEW_PACKAGE_NEW_FILE = "java.view.package.newFile";
 
@@ -185,5 +187,14 @@ export function executeJavaLanguageServerCommand(...rest: any[]) {
 
 export async function executeJavaExtensionCommand(commandName: string, ...rest: any[]) {
     // TODO: need to handle error and trace telemetry
-    return commands.executeCommand(commandName, ...rest);
+    return commands.executeCommand(commandName, ...rest);   
 }
+
+
+
+vscode.commands.registerCommand('java.view.package.revealFileInVSCode', (uri: vscode.Uri) => {
+    if (uri) {
+        vscode.commands.executeCommand('workbench.view.explorer');
+        vscode.commands.executeCommand('revealInExplorer', uri);
+    }
+});


### PR DESCRIPTION
@microsoft-github-policy-service agree

Added a new context menu option "Reveal in VS Code Explorer" in Java Project view.
Changes:
Introduced new command `java.view.package.revealFileInVSCode`
Opens selected path directly in VS Code Explorer

Benefit
Improves developer workflow by avoiding switching to external file manager.

Related Issue
Addresses the request to add an option for revealing the selected path in VS Code Explorer.