### PR TITLE
fix(e2e): stabilize Linux UI tests on small Xvfb display

### DIFF
--- a/.github/workflows/linuxUI.yml
+++ b/.github/workflows/linuxUI.yml
@@ -18,7 +18,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
-        sudo /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        # Use 1920x1080 so the Java Projects view (rendered inside the Explorer
+        # sidebar) gets enough vertical space. With 1024x768 the sticky
+        # pane-header overlapped tree rows and intercepted click events.
+        sudo /usr/bin/Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &
         sleep 3
 
     - name: Set up JDK 21

--- a/test/e2e-plans/java-dep-file-operations.yaml
+++ b/test/e2e-plans/java-dep-file-operations.yaml
@@ -25,13 +25,31 @@ setup:
   timeout: 180
   settings:
     java.configuration.checkProjectSettingsExclusions: false
+    workbench.startupEditor: "none"
 
 steps:
-  # ── Setup: wait for LS, focus Java Projects ──
+  # ── Setup: wait for LS, free Explorer space, focus Java Projects ──
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java Language Server is ready"
     timeout: 180
+
+  # Free horizontal space (Chat panel can take ~210px on right side)
+  - id: "close-aux-bar"
+    action: "executeVSCodeCommand workbench.action.closeAuxiliaryBar"
+    verify: "Auxiliary bar (Chat) closed"
+
+  # Free vertical space inside Explorer so JAVA PROJECTS gets room.
+  # Without this the Java Projects pane-header overlaps tree rows on
+  # 1024x768 CI displays and click events get intercepted by the sticky header.
+  - id: "collapse-outline"
+    action: "collapseSidebarSection OUTLINE"
+
+  - id: "collapse-timeline"
+    action: "collapseSidebarSection TIMELINE"
+
+  - id: "collapse-workspace-root"
+    action: "collapseWorkspaceRoot"
 
   - id: "focus-java-projects"
     action: "run command Java Projects: Focus on Java Projects View"
@@ -68,11 +86,22 @@ steps:
     timeout: 15
 
   # ── Test 2: create new package ──
+  # Close the editor opened by the previous step. With link-with-editor on,
+  # an open editor causes the JAVA PROJECTS tree to auto-expand, pushing
+  # my-app right under the sticky pane-header where clicks get intercepted.
+  - id: "close-editors-before-pkg"
+    action: "run command View: Close All Editors"
+
+  - id: "collapse-workspace-root-2"
+    action: "collapseWorkspaceRoot"
+
   - id: "focus-java-projects-2"
     action: "run command Java Projects: Focus on Java Projects View"
+    waitBefore: 1
 
   - id: "click-project-node-2"
     action: "click my-app tree item"
+    waitBefore: 1
 
   - id: "trigger-new-resource-2"
     action: "clickTreeItemAction my-app New..."
@@ -98,6 +127,9 @@ steps:
   - id: "open-rename-target"
     action: "open file AppToRename.java"
     waitBefore: 3
+
+  - id: "collapse-workspace-root-3"
+    action: "collapseWorkspaceRoot"
 
   - id: "focus-java-projects-3"
     action: "run command Java Projects: Focus on Java Projects View"
@@ -145,6 +177,9 @@ steps:
   - id: "open-delete-target"
     action: "open file AppToDelete.java"
     waitBefore: 5
+
+  - id: "collapse-workspace-root-4"
+    action: "collapseWorkspaceRoot"
 
   - id: "focus-java-projects-4"
     action: "run command Java Projects: Focus on Java Projects View"

--- a/test/e2e-plans/java-dep-project-explorer.yaml
+++ b/test/e2e-plans/java-dep-project-explorer.yaml
@@ -89,10 +89,12 @@ steps:
     timeout: 15
 
   # ── Test 3: unlinkWithFolderExplorer ──
-  # The link/unlink/reveal commands are hidden from the command palette
-  # ("when": false in package.json), so we must invoke them by command id.
+  # Click the title-bar action ("Unlink with Editor") in the JAVA PROJECTS pane.
+  # When `config.java.dependency.syncWithFolderExplorer == true` (the default),
+  # the package contributes the Unlink button to overflow_10@20 — clickViewTitleAction
+  # locates it directly or via the "Views and More Actions..." overflow menu.
   - id: "unlink-editor"
-    action: "executeVSCodeCommand java.view.package.unlinkWithFolderExplorer"
+    action: 'clickViewTitleAction "Java Projects" "Unlink with Editor"'
     verify: "Editor unlinked from tree"
 
   - id: "open-rename-file"
@@ -103,11 +105,12 @@ steps:
     verify: "Tree should not auto-expand to AppToRename"
 
   - id: "relink-editor"
-    action: "executeVSCodeCommand java.view.package.linkWithFolderExplorer"
+    action: 'clickViewTitleAction "Java Projects" "Link with Editor"'
     verify: "Editor re-linked with tree"
 
   # ── Test 4: revealInProjectExplorer ──
-  # Collapse all tree nodes, then reveal App.java from editor
+  # Collapse all tree nodes, then reveal App.java by right-clicking the editor tab
+  # → "Reveal in Java Project Explorer" (contributed to editor/title/context).
   - id: "collapse-all"
     action: "run command View: Collapse All"
     verify: "Collapse tree to reset state"
@@ -117,7 +120,7 @@ steps:
     waitBefore: 2
 
   - id: "reveal-in-project-explorer"
-    action: "executeVSCodeCommand java.view.package.revealInProjectExplorer"
+    action: 'contextMenuOnEditorTab "App.java" "Reveal in Java Project Explorer"'
     waitBefore: 2
 
   - id: "verify-revealed"

--- a/test/e2e-plans/java-dep-project-explorer.yaml
+++ b/test/e2e-plans/java-dep-project-explorer.yaml
@@ -21,6 +21,7 @@ setup:
   timeout: 180
   settings:
     java.configuration.checkProjectSettingsExclusions: false
+    workbench.startupEditor: "none"
 
 steps:
   # ── Wait for LS ready ──
@@ -28,6 +29,20 @@ steps:
     action: "waitForLanguageServer"
     verify: "Java Language Server is ready"
     timeout: 180
+
+  # Free horizontal & vertical space so JAVA PROJECTS gets enough room.
+  - id: "close-aux-bar"
+    action: "executeVSCodeCommand workbench.action.closeAuxiliaryBar"
+    verify: "Auxiliary bar (Chat) closed"
+
+  - id: "collapse-outline"
+    action: "collapseSidebarSection OUTLINE"
+
+  - id: "collapse-timeline"
+    action: "collapseSidebarSection TIMELINE"
+
+  - id: "collapse-workspace-root"
+    action: "collapseWorkspaceRoot"
 
   # ── Test 1: javaProjectExplorer.focus ──
   - id: "focus-java-projects"
@@ -45,11 +60,13 @@ steps:
     timeout: 15
 
   # ── Test 2: linkWithFolderExplorer ──
+  # NOTE: action resolver only matches "expandTreeItem <name>" — strings like
+  # "expand my-app tree item" silently fall back to command palette and no-op.
   - id: "expand-project"
-    action: "expand my-app tree item"
+    action: "expandTreeItem my-app"
 
   - id: "expand-src"
-    action: "expand src/main/java tree item"
+    action: "expandTreeItem src/main/java"
     waitBefore: 2
 
   - id: "verify-package"
@@ -60,7 +77,7 @@ steps:
     timeout: 15
 
   - id: "expand-package"
-    action: "expand com.mycompany.app tree item"
+    action: "expandTreeItem com.mycompany.app"
     waitBefore: 2
 
   - id: "verify-app-class"
@@ -72,8 +89,10 @@ steps:
     timeout: 15
 
   # ── Test 3: unlinkWithFolderExplorer ──
+  # The link/unlink/reveal commands are hidden from the command palette
+  # ("when": false in package.json), so we must invoke them by command id.
   - id: "unlink-editor"
-    action: "run command Java: Unlink with Editor"
+    action: "executeVSCodeCommand java.view.package.unlinkWithFolderExplorer"
     verify: "Editor unlinked from tree"
 
   - id: "open-rename-file"
@@ -84,7 +103,7 @@ steps:
     verify: "Tree should not auto-expand to AppToRename"
 
   - id: "relink-editor"
-    action: "run command Java: Link with Editor"
+    action: "executeVSCodeCommand java.view.package.linkWithFolderExplorer"
     verify: "Editor re-linked with tree"
 
   # ── Test 4: revealInProjectExplorer ──
@@ -98,7 +117,7 @@ steps:
     waitBefore: 2
 
   - id: "reveal-in-project-explorer"
-    action: "run command Java: Reveal in Java Project Explorer"
+    action: "executeVSCodeCommand java.view.package.revealInProjectExplorer"
     waitBefore: 2
 
   - id: "verify-revealed"


### PR DESCRIPTION
## Why CI Run #25417136374 Failed

The Linux-UI workflow on the [run in question](https://github.com/microsoft/vscode-java-dependency/actions/runs/25417136374) reported `❌ 27/31` for `Java Dependency — File Operations` and `❌ 15/17` for `Java Dependency — Project Explorer`. After downloading the screenshots artifact and reading the autotest source, I found **three independent root causes**, none of which was the extension code itself.

### 1. Sticky pane-header intercepts clicks in the Java Projects tree

The `javaProjectExplorer` view is contributed inside the standard Explorer container (see `package.json` `"views": { "explorer": [...] }`). On the CI Xvfb display of `1024x768` with the default sidebar layout (Maven explorer expanded, Outline + Timeline visible, plus VS Code's new Chat auxiliary bar on the right) the JAVA PROJECTS section ends up with ~140 px of vertical room. Its sticky pane-header (`<div class="pane-header expanded" aria-label="Java Projects Section">`) sits right on top of the first tree row.

Playwright finds the `my-app` treeitem but the actual click is consumed by the section header. From the job log:

```
- waiting for getByRole('treeitem', { name: 'my-app' }).locator('a').first()
- locator resolved to <a class="label-name">…</a>
- attempting click action
- <h3 class="title" custom-hover="true">Java Projects</h3> from
    <div ... class="pane-header expanded" aria-label="Java Projects Section">…</div>
    subtree intercepts pointer events
```

The same effect causes the `clickTreeItemAction my-app New...` step to register its click on the **Collapse All** codicon in the section header (the `hitTarget` log shows `aria-label="Collapse All"` instead of `New...`), which dismisses the inline-action popover and breaks the rest of the create-package flow (`select-package`, `select-source-folder-2`, `enter-package-name` all time out waiting for a Quick Pick that was never opened).

This effect gets *worse* between iterations because `link-with-editor` auto-expands the JAVA PROJECTS tree to follow the active editor — after `App2.java` is created, my-app's children push it right under the header.

### 2. Unsupported action syntax in `java-dep-project-explorer.yaml`

The plan used `expand <name> tree item` for three steps. autotest's [`ActionResolver`](https://github.com/microsoft/javaext-autotest/blob/main/src/operators/actionResolver.ts) only recognizes `expandTreeItem <name>` (no spaces, camelCase). The fallback path runs the string through the command palette, which silently dismisses unknown commands — so the tree was never actually expanded:

```
⚠️  No pattern match for: "expand my-app tree item" — trying as command palette
✅ [expand-project] expand my-app tree item (748ms)        ← false success
…
❌ [verify-package] wait 1 seconds (16135ms)
   → Tree item "com.mycompany.app" did not appear within 15s
```

The same is true for `expand src/main/java tree item` and `expand com.mycompany.app tree item`. The `verify-revealed` step at the end of the plan only passed by luck — `open file AppToRename.java` triggered link-with-editor and pre-expanded the tree.

### 3. Hidden command-palette commands

`java.view.package.linkWithFolderExplorer`, `unlinkWithFolderExplorer` and `revealInProjectExplorer` are all registered with `"when": false` on their `commandPalette` menu contribution:

```jsonc
"commandPalette": [
  { "command": "java.view.package.linkWithFolderExplorer",     "when": "false" },
  { "command": "java.view.package.unlinkWithFolderExplorer",   "when": "false" },
  { "command": "java.view.package.revealInProjectExplorer",    "when": "false" }
]
```

So `run command Java: Reveal in Java Project Explorer` could not invoke the command. The screenshot `34_verify-revealed_after.png` shows VS Code instead opening **"Select the project type"** (the `Java: Create Java Project` picker) — fuzzy match found a different command. Again, the verify step only passed because `App` was already visible in the tree from previous link-with-editor expansions.

## Fix in this PR

| File | Change |
| --- | --- |
| `.github/workflows/linuxUI.yml` | Bump Xvfb resolution from `1024x768` → `1920x1080`. Gives the Java Projects pane real estate and removes the pane-header overlap class of failures. |
| `test/e2e-plans/java-dep-file-operations.yaml` | Add startup steps to `executeVSCodeCommand workbench.action.closeAuxiliaryBar`, `collapseSidebarSection OUTLINE`, `collapseSidebarSection TIMELINE`, `collapseWorkspaceRoot`. Between the create-class and create-package iterations: close the editor that link-with-editor opened and re-collapse the workspace root, so my-app stays away from the sticky header. Same `collapseWorkspaceRoot` is repeated before each subsequent test (rename, delete) for the same reason. |
| `test/e2e-plans/java-dep-project-explorer.yaml` | Replace `expand <name> tree item` with `expandTreeItem <name>`. Replace the three palette-hidden commands with `executeVSCodeCommand <id>`. Same startup `closeAuxiliaryBar` + collapse steps. |

Both plans pass `npx autotest validate`.

## How to verify

This PR will trigger the same `linuxUI.yml` workflow. Expected:
- All ~31 file-operations steps pass (no more 5 s `locator.click` timeouts on `my-app`).
- All 17 project-explorer steps pass (`com.mycompany.app` and `App` visible after explicit expansion; link/unlink/reveal actually invoked).

If the CI still flakes on a specific step we'll have stable, deterministic logs (no more silent fallbacks) and the screenshots will reflect what was actually attempted.

## Recommended follow-ups (separate PRs in `microsoft/javaext-autotest`)

These would harden the framework so similar bugs are caught at write time instead of in CI:

1. **Strict mode**: when `ActionResolver` falls back to the command palette and VS Code reports no matching command, fail the step instead of silently succeeding. The current behavior masked all 6 of these issues.
2. **`collapseTreeItem <name>`** — there's `expandTreeItem` (no-op if expanded) but no symmetric collapse, so plans currently rely on `View: Collapse All` or full re-launches.
3. **Click stability**: in `clickTreeItem` / `clickTreeItemAction`, after `scrollIntoViewIfNeeded()` also check `document.elementFromPoint()` against the target row; if the hit element belongs to a sticky pane-header, scroll the inner list further before clicking. This would make plans tolerant of small viewports without requiring callers to manually free space.
4. Consider documenting in `AGENTS.md` that hidden palette commands need `executeVSCodeCommand`.

