### PR TITLE
fix(e2e): collapse JAVA PROJECTS tree before second click-project-node

### DIFF
--- a/test/e2e-plans/java-dep-file-operations.yaml
+++ b/test/e2e-plans/java-dep-file-operations.yaml
@@ -99,6 +99,13 @@ steps:
     action: "run command Java Projects: Focus on Java Projects View"
     waitBefore: 1
 
+  # Test 1 expanded my-app → src/main/java → com.mycompany.app to reveal the
+  # newly-created App2.java. Reset the JAVA PROJECTS tree so my-app is back
+  # at row 0 and not occluded by the sticky pane-header on the next click.
+  - id: "collapse-java-projects-tree-2"
+    action: 'clickViewTitleAction "Java Projects" "Collapse All"'
+    waitBefore: 1
+
   - id: "click-project-node-2"
     action: "click my-app tree item"
     waitBefore: 1


### PR DESCRIPTION
## Why

CI run [#25422861436](https://github.com/microsoft/vscode-java-dependency/actions/runs/25422861436/job/74568978413) failed on the merge of #1003 with `Java Dependency — File Operations` at **35/39**:

```
❌ [click-project-node-2] click my-app tree item
   <h3 class="title">Java Projects</h3> from <div class="pane-header"...>
   intercepts pointer events
```

`#1003` had already added `closeAuxiliaryBar`, `collapseSidebarSection OUTLINE/TIMELINE`, `collapseWorkspaceRoot`, and `focus-java-projects` before the **first** `click-project-node`, which fixed the initial click. But the second click failed for a different reason.

## Root cause

Between Test 1 and Test 2 of the file-operations plan:

1. `enter-class-name App2` opens `App2.java` in an editor.
2. **Link-with-editor (default ON)** auto-expands the JAVA PROJECTS tree all the way to `my-app → src/main/java → com.mycompany.app → App2.java` to reveal the newly-created file.
3. Test 2 starts: `close-editors-before-pkg`, `collapse-workspace-root-2`, `focus-java-projects-2`.
4. `collapseWorkspaceRoot` only collapses the **Explorer view's** workspace folder — it does **not** collapse the JAVA PROJECTS view itself.
5. Result: when `click-project-node-2` runs, `my-app` is no longer at row 0 of the JAVA PROJECTS view; it's been pushed deeper, gets scrolled, and ends up directly underneath the sticky `.pane-header .title` "Java Projects". The pane-header intercepts the click — CI log shows the actual hit target was the `codicon-collapse-all` view-title button.

## Fix

Add a `clickViewTitleAction "Java Projects" "Collapse All"` step before `click-project-node-2` to reset the JAVA PROJECTS tree to its initial collapsed state, putting `my-app` back at row 0 (clearly below the sticky pane-header).

Test 3 (rename) and Test 4 (delete) don't need this guard — they click *leaf* nodes (`AppToRename`, `AppToDelete`) that link-with-editor freshly reveals at the bottom of the viewport, where the sticky pane-header isn't a concern. CI confirmed both passed (`✅ select-rename-target`, `✅ delete-context-menu`).

## Verification

Ran the full plan locally on Windows with `@vscjava/vscode-autotest@0.6.6` against a freshly-built `vscode-java-dependency.vsix`:

```
✅ [collapse-java-projects-tree-2] clickViewTitleAction "Java Projects" "Collapse All" (2319ms)
✅ [click-project-node-2] click my-app tree item (2003ms)
...
📊 Results: 40/40 passed
```

## Compatibility

`clickViewTitleAction` was introduced in autotest 0.6.6, which is published on npm and what the workflow installs via `npm install -g @vscjava/vscode-autotest`.
