### PR TITLE
chore: bump version to 0.27.3

### DIFF
--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -88,13 +88,6 @@ extends:
                 displayName: Replace AI Key
                 inputs:
                   script: npx json@9.0.6 -I -f package.json -e "this.aiKey=\"%AI_KEY%\""
-              - task: PowerShell@2
-                displayName: Update package.json for stable
-                inputs:
-                  targetType: inline
-                  script: |-
-                    node ./scripts/prepare-stable-build.js
-                    Move-Item -Path "./package.stable.json" -Destination "./package.json" -Force
               - task: CmdLine@2
                 displayName: vsce package
                 inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 0.27.3
 
+- feat - Enable Copilot LLM tools / chat skills / chat instructions in stable builds
 - perf - Narrow to Java project to show the explorer in https://github.com/microsoft/vscode-java-dependency/pull/1010
 - perf - Use incremental build by default in https://github.com/microsoft/vscode-java-dependency/pull/998
 - feat - Add `revealInProjectExplorer` command in https://github.com/microsoft/vscode-java-dependency/pull/996

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "vscode-java-dependency" extension will be documented
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.27.3
+
+- perf - Narrow to Java project to show the explorer in https://github.com/microsoft/vscode-java-dependency/pull/1010
+- perf - Use incremental build by default in https://github.com/microsoft/vscode-java-dependency/pull/998
+- feat - Add `revealInProjectExplorer` command in https://github.com/microsoft/vscode-java-dependency/pull/996
+- fix - Support Unicode identifiers in Java class name validation in https://github.com/microsoft/vscode-java-dependency/pull/993
+- fix - Adjust parameter to require the right name for file uri in https://github.com/microsoft/vscode-java-dependency/pull/1000
+
 ## 0.27.2
 
 - perf - Progressive project tree view during import in https://github.com/microsoft/vscode-java-dependency/pull/982

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-java-dependency",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-java-dependency",
-      "version": "0.27.2",
+      "version": "0.27.3",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-language-server": "^1.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-java-dependency",
   "displayName": "Project Manager for Java",
   "description": "%description%",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "publisher": "vscjava",
   "preview": false,
   "aiKey": "5c642b22-e845-4400-badb-3f8509a70777",

--- a/scripts/prepare-stable-build.js
+++ b/scripts/prepare-stable-build.js
@@ -4,14 +4,4 @@ const packageJsonPath = "./package.json";
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
 packageJson.preview = false;
 
-if (packageJson.contributes) {
-    delete packageJson.contributes.languageModelTools;
-    delete packageJson.contributes.chatSkills;
-    delete packageJson.contributes.chatInstructions;
-
-    if (packageJson.contributes.configuration && packageJson.contributes.configuration.properties) {
-        delete packageJson.contributes.configuration.properties["vscode-java-dependency.enableLspTools"];
-    }
-}
-
 fs.writeFileSync("./package.stable.json", `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/scripts/prepare-stable-build.js
+++ b/scripts/prepare-stable-build.js
@@ -1,7 +1,0 @@
-const fs = require("fs");
-
-const packageJsonPath = "./package.json";
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
-packageJson.preview = false;
-
-fs.writeFileSync("./package.stable.json", `${JSON.stringify(packageJson, null, 2)}\n`);


### PR DESCRIPTION
Bump version to 0.27.3.

### Changes

- perf - Narrow to Java project to show the explorer (#1010)
- perf - Use incremental build by default (#998)
- feat - Add `revealInProjectExplorer` command (#996)
- fix - Support Unicode identifiers in Java class name validation (#993)
- fix - Adjust parameter to require the right name for file uri (#1000)