### PR TITLE
build: release 0.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 0.27.5
 
 - fix - Check GHCP modernization version before call gotoAgentMode command in https://github.com/microsoft/vscode-java-dependency/pull/1022
+- perf - Tune Java LSP tool selection guidance in https://github.com/microsoft/vscode-java-dependency/pull/1020
 
 ## 0.27.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-java-dependency",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-java-dependency",
-      "version": "0.27.4",
+      "version": "0.27.5",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-language-server": "^1.388.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-java-dependency",
   "displayName": "Project Manager for Java",
   "description": "%description%",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "publisher": "vscjava",
   "preview": false,
   "aiKey": "5c642b22-e845-4400-badb-3f8509a70777",


### PR DESCRIPTION
Bump version to `0.27.5` and complete the changelog for this release.

### Changes
- Bump `version` to `0.27.5` in `package.json` and `package-lock.json` (the `0.27.5` CHANGELOG heading landed in #1023 without the version bump).
- Add the missing user-facing changelog entry for #1020 (perf: tune Java LSP tool selection guidance).

Dependency bumps (#1018) and test-only PRs (#1019) are omitted, consistent with the existing changelog convention of listing only user-facing changes.