### PR TITLE
chore: improve java upgrade telemetry tracking and extension installation flow

### DIFF
--- a/src/upgrade/display/notificationManager.ts
+++ b/src/upgrade/display/notificationManager.ts
@@ -93,6 +93,7 @@ class NotificationManager implements IUpgradeIssuesRenderer {
                 sendInfo(operationId, {
                     operationName: "java.dependency.upgradeNotification.show",
                     extensionState,
+                    source: hasCVEIssue ? Upgrade.SOURCE_CVE : Upgrade.SOURCE_JAVA_UPGRADE,
                 });
 
                 const buttons = hasCVEIssue

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -197,6 +197,11 @@ export async function checkOrInstallAppModExtensionForUpgrade(
         }
 
         await commands.executeCommand("workbench.extensions.installExtension", ExtensionName.APP_MODERNIZATION_FOR_JAVA);
+        sendInfo(operationId, {
+            operationName: "java.dependency.upgradeFlow.result",
+            upgradeFlowStep: "installSucceeded",
+            extensionState: state,
+        });
 
         if (state === "outdated") {
             // Extension was updated (not freshly installed) — reload required

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -197,6 +197,10 @@ export async function checkOrInstallAppModExtensionForUpgrade(
         }
 
         await commands.executeCommand("workbench.extensions.installExtension", ExtensionName.APP_MODERNIZATION_FOR_JAVA);
+        sendInfo(operationId, {
+            operationName: "java.dependency.upgradeFlow.installSucceeded",
+            extensionState: state,
+        });
 
         if (state === "outdated") {
             // Extension was updated (not freshly installed) — reload required
@@ -221,16 +225,13 @@ export async function checkOrInstallAppModExtensionForUpgrade(
 
         await checkOrPromptToEnableAppModExtension("upgrade");
 
-        // Wait briefly for the newly installed extension to activate
+        // Give the newly installed extension a moment to activate before proceeding
         await new Promise(resolve => setTimeout(resolve, 2000));
 
-        // Re-check if the newly installed extension is active and meets version requirement
-        const newState = getExtensionState(extensionIdToCheck);
-        const canProceed = newState === "up-to-date";
         sendInfo(operationId, {
             operationName: "java.dependency.upgradeFlow.result",
-            upgradeFlowResult: canProceed ? "proceeded" : "activation-timeout",
+            upgradeFlowResult: "proceeded",
         });
-        return canProceed;
+        return true;
     })();
 }

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -200,7 +200,7 @@ export async function checkOrInstallAppModExtensionForUpgrade(
         sendInfo(operationId, {
             operationName: "java.dependency.upgradeFlow.result",
             upgradeFlowStep: "installSucceeded",
-            extensionState: state,
+            installType: state === "outdated" ? "updated" : "installed",
         });
 
         if (state === "outdated") {

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -224,8 +224,6 @@ export async function checkOrInstallAppModExtensionForUpgrade(
             return false;
         }
 
-        await checkOrPromptToEnableAppModExtension("upgrade");
-
         // Give the newly installed extension a moment to activate before proceeding
         await new Promise(resolve => setTimeout(resolve, 2000));
 

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -224,8 +224,9 @@ export async function checkOrInstallAppModExtensionForUpgrade(
             return false;
         }
 
-        // Give the newly installed extension a moment to activate before proceeding
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        // Wait until the freshly installed extension is registered, returning as
+        // soon as it is ready, or after a 5s timeout fallback at the latest.
+        await waitForExtensionReady(extensionIdToCheck, 5000);
 
         sendInfo(operationId, {
             operationName: "java.dependency.upgradeFlow.result",
@@ -233,4 +234,25 @@ export async function checkOrInstallAppModExtensionForUpgrade(
         });
         return true;
     })();
+}
+
+function waitForExtensionReady(extensionId: string, timeoutMs: number): Promise<void> {
+    return new Promise<void>(resolve => {
+        if (extensions.getExtension(extensionId)) {
+            resolve();
+            return;
+        }
+        let timer: NodeJS.Timeout;
+        const disposable = extensions.onDidChange(() => {
+            if (extensions.getExtension(extensionId)) {
+                clearTimeout(timer);
+                disposable.dispose();
+                resolve();
+            }
+        });
+        timer = setTimeout(() => {
+            disposable.dispose();
+            resolve();
+        }, timeoutMs);
+    });
 }

--- a/src/upgrade/utility.ts
+++ b/src/upgrade/utility.ts
@@ -197,10 +197,6 @@ export async function checkOrInstallAppModExtensionForUpgrade(
         }
 
         await commands.executeCommand("workbench.extensions.installExtension", ExtensionName.APP_MODERNIZATION_FOR_JAVA);
-        sendInfo(operationId, {
-            operationName: "java.dependency.upgradeFlow.installSucceeded",
-            extensionState: state,
-        });
 
         if (state === "outdated") {
             // Extension was updated (not freshly installed) — reload required


### PR DESCRIPTION
## Why

Production telemetry from `vscode-java-dependency` v0.27.5 (7d) surfaced gaps in the
upgrade notification -> `upgradeFlow` funnel (follow-up to #1022, which already cut the
original "command not found" error rate from 23.2% to 0.5%):

- The `upgradeNotification.show` event could not be split by CVE vs upgrade, so
  per-bucket click rates were diluted at the NOTIFY level.
- 41% of `not-installed` flow starts were classified as `activation-timeout`, but **0** of
  those carried an install error. The post-install check was the problem, not the install:
  `installExtension` resolves on install completion, while the code then immediately
  re-read `getExtensionState()` and a fixed `setTimeout(2000)` before the extension had
  finished registering, so a healthy install was frequently mislabeled as a timeout.

## What changed

**1. Split NOTIFY by CVE vs upgrade (`notificationManager.ts`)**
Add a `source` field (`SOURCE_CVE` / `SOURCE_JAVA_UPGRADE`) to the
`upgradeNotification.show` event, reusing the same constants the click handler already
passes to the upgrade command so NOTIFY and downstream funnel stages align on one dimension.

**2. Record install completion as a step on the existing result event (`utility.ts`)**
Emit install success right after `installExtension` resolves, but **without** a new business
`operationName`: it reuses the stable `java.dependency.upgradeFlow.result` event with an
`upgradeFlowStep: "installSucceeded"` dimension, plus `installType` (`"installed"` for a
fresh install, `"updated"` for an outdated one). `installType` is derived from the
**pre-install** state, so it stays unambiguous and avoids an unreliable post-install state
recompute.

**3. Replace the unreliable activation wait with event-driven readiness (`utility.ts`)**
On the `not-installed` path, drop the `getExtensionState()` re-check that produced the false
`activation-timeout`. A new `waitForExtensionReady()` helper resolves immediately if the
extension is already registered, otherwise listens on `extensions.onDidChange` and proceeds
as soon as it appears, with a 5s timeout fallback. The flow then reports
`result: "proceeded"` and returns `true`.

The upgrade flow no longer calls `checkOrPromptToEnableAppModExtension()`: `getExtension()`
returns `undefined` both when an extension is disabled and when it is freshly installed but
not yet activated, so the "seems disabled, enable it manually" prompt was misleading right
after a successful install. The helper is unchanged and still used by the modernization flow.
