### PR TITLE
ci: run npm through script steps instead of the Npm@1 task

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -55,16 +55,10 @@ extends:
                 inputs:
                   versionSpec: 20.x
               - template: /.azure-pipelines/npm-cfs.yml@self
-              - task: Npm@1
+              - script: npm install --verbose
                 displayName: npm install
-                inputs:
-                  verbose: true
-              - task: Npm@1
+              - script: npm run build-server
                 displayName: npm run build-server
-                inputs:
-                  command: custom
-                  verbose: false
-                  customCommand: run build-server
               - task: Bash@3
                 displayName: vsce package
                 inputs:

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -69,10 +69,8 @@ extends:
               - script: java --version
                 displayName: 'Check Java installation'
               - template: /.azure-pipelines/npm-cfs.yml@self
-              - task: Npm@1
+              - script: npm install
                 displayName: npm install
-                inputs:
-                  verbose: false
               - task: CmdLine@2
                 displayName: npx gulp build_server
                 inputs:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -64,10 +64,8 @@ extends:
               - script: java --version
                 displayName: 'Check Java installation'
               - template: /.azure-pipelines/npm-cfs.yml@self
-              - task: Npm@1
+              - script: npm install
                 displayName: npm install
-                inputs:
-                  verbose: false
               - task: CmdLine@2
                 displayName: npx gulp build_server
                 inputs:


### PR DESCRIPTION
## Problem

The CFS onboarding merged earlier routes npm through the Central Feed Service using two job level settings:

- `npm_config_registry` — the CFS feed URL, exported as an environment variable
- `npm_config_userconfig` — `$(Agent.TempDirectory)/.npmrc`, into which `NpmAuthenticate@0` writes the feed credential

The `Npm@1` task is incompatible with that arrangement. It generates its own `.npmrc` and points npm at it by setting `npm_config_userconfig` itself, which discards the credential. The registry is unaffected, because it arrives as an environment variable and npm ranks environment above every config file. The task therefore requests packages from the CFS feed with no token.

Observed in [build 31831248](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31831248):

```
registry   = "https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/"
userconfig = "/mnt/vss/_work/1/npm/31831248.npmrc"

npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

The three CFS steps preceding it all reported `succeeded`; only the `Npm@1` step failed.

## Change

Every `Npm@1` step becomes a plain `script:` step, which inherits both the registry and the userconfig from the job environment.

```yaml
- task: Npm@1              →   - script: npm install
  displayName: npm install         displayName: npm install
  inputs:
    verbose: false

- task: Npm@1              →   - script: npm run compile
  displayName: npm run compile     displayName: npm run compile
  inputs:
    command: custom
    verbose: false
    customCommand: run compile
```

Steps that do not restore packages are converted as well. They do not fail today, but they run against the CFS feed unauthenticated, so any script that later reaches the registry — an `npx` invocation, for example — would fail the same way. Converting all of them leaves a single mechanism in place.

`displayName`, `workingDir`, `enabled` and `verbose` are preserved on every step.

This matches the configuration already validated in `microsoft/vscode-gradle`, where npm is invoked from plain shell steps and [build 31830854](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31830854) restored 525 of 525 packages through the CFS feed.

## Validation

Each affected pipeline definition was expanded through the Azure DevOps pipeline preview API on this branch; all compile and retain the CFS steps.

## Context

SFI Network Isolation / MountainPass SR21, ICM 840100965.
