### PR TITLE
build: drop the unreachable snapshot repository and pin p2 to its origin

### DIFF
--- a/jdtls.ext/pom.xml
+++ b/jdtls.ext/pom.xml
@@ -131,13 +131,4 @@
             </properties>
         </profile>
     </profiles>
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -18,7 +18,10 @@ const jvmOptions = [
 const env = { ...process.env };
 env.MAVEN_OPTS = env.MAVEN_OPTS ? env.MAVEN_OPTS + ' ' + jvmOptions : jvmOptions;
 
-const mvnCommand = `${mvnw()} clean package`;
+// `eclipse.p2.mirrors=false` stops p2 from following download.eclipse.org's mirror
+// redirect, which hands out a different third party host per request and makes the
+// set of addresses the build contacts impossible to express as an allow list.
+const mvnCommand = `${mvnw()} clean package -Declipse.p2.mirrors=false`;
 cp.execSync(mvnCommand, {cwd:server_dir, stdio:[0,1,2], env: env} );
 copy(path.join(server_dir, 'com.microsoft.jdtls.ext.core/target'), path.resolve('server'), (file) => {
     return /^com.microsoft.jdtls.ext.core.*.jar$/.test(file);


### PR DESCRIPTION
Part of the remediation for ICM [840100965](https://portal.microsofticm.com/imp/v5/incidents/details/840100965/summary) (MountainPass SR21, SFI Network Isolation / CFS adoption). The npm side of these pipelines is handled by #1046; this PR is the Maven side.

The goal of SR21 is that a build can run on a network isolated pool. That requires knowing every host the build contacts. This PR removes two obstacles to that, neither of which changes what the build produces.

## 1. `oss.sonatype.org` is unreachable by construction

`jdtls.ext/pom.xml` declares a **snapshots** repository, but every artifact resolved against it carries a **release** version, so Maven can only ever get a 404 back. Build [31823304](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31823304):

| | count |
|---|---|
| `Downloading from oss.sonatype.org` | 42 |
| `Downloaded from oss.sonatype.org` | **0** |

Every one of those 42 requests failed and Maven fell back to Central. Removing the entry drops an external host and 42 failed round trips, and cannot change resolution because it never resolved anything.

## 2. p2 mirror redirects make the host set unknowable

`download.eclipse.org` answers p2 requests with a redirect to a mirror picked **per request** from a pool of third party hosts. `com.microsoft.jdtls.ext.tp.target` references `/eclipse/updates/4.35/` and `/releases/2024-12/`, both of which are mirrored, so that build read most of its bundles from five hosts the repository never declares:

```
eclipse.mirror.rafal.ca   32     ftp2.osuosl.org      12
ca.mirrors.cicku.me       26     mirror.cs.odu.edu     4
mirror.aarnet.edu.au      12
```

for example:

```
[INFO] Downloaded from p2: https://mirror.aarnet.edu.au/pub/eclipse/eclipse/updates/4.35/R-4.35-202502280140/plugins/org.eclipse.core.runtime_3.33.0...
```

The selection is per request, so the host set differs run to run and cannot be enumerated in advance — no allow list can be written for it. `-Declipse.p2.mirrors=false` ([Tycho system property](https://tycho.eclipseprojects.io/doc/main/SystemProperties.html); the older `-Dtycho.disableP2Mirrors=true` is deprecated) makes p2 read from the URL in the target definition, collapsing those five hosts into the one the target already names.

## What this does not do

Maven Central traffic (`repo.maven.apache.org`, 927 unique URLs in that build) still goes direct. Routing it through the CFS feed needs `MavenAuthenticate@0` plus a generated `settings.xml` mirror, which is a larger change and is deliberately not bundled here. After this PR the external host set for `npx gulp build_server` is:

| host | status |
|---|---|
| `repo.maven.apache.org` | to be routed through CFS (`vscjava` already has the Maven Central upstream) |
| `download.eclipse.org` | P2 — Azure Artifacts does not support the protocol, so this needs an SR21 exception |

Two named hosts is something an exception request can actually be written against.

## Verification

`npx gulp build_server` produces the same `com.microsoft.jdtls.ext.core-*.jar`. The claim to check in CI is that `oss.sonatype.org` and every `mirror*` host disappear from the build log while the server still builds.
