### PR TITLE
ci: Revert fast-uri 3.1.5 and delay Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    # CI restores packages from the Central Feed Service, which withholds
+    # upstream versions until they are roughly a week old (measured at ~6.8
+    # days; both the packument entry and the tarball return 404 before then).
+    # Dependabot's built-in cooldown is only 3 days, so bumps otherwise land in
+    # a window where the feed 404s and the build fails. 10 days leaves margin
+    # in case the feed's ingestion lag drifts.
+    cooldown:
+      default-days: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1750,9 +1750,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -5464,9 +5464,9 @@
       }
     },
     "fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true
     },
     "fastest-levenshtein": {


### PR DESCRIPTION
## Summary
- revert `fast-uri` from 3.1.5 to 3.1.4
- delay npm Dependabot updates by 10 days so Central Feed Service can ingest new package versions

## Context
CI restores npm packages through CFS. Newly released versions can return 404 until CFS ingestion completes.