### PR TITLE
ci: pin Windows signing plugin to 1.1.1306

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -33,11 +33,7 @@ extends:
             templateContext:
               mb:
                 signing:
-                  enabled: true
-                  signType: real
-                  signWithProd: true
-                  zipSources: false
-                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                  enabled: false
               outputs:
                 - output: pipelineArtifact
                   artifactName: extension
@@ -47,6 +43,19 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: true
+              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate MicroBuild feed
+              - task: MicroBuildSigningPlugin@4
+                displayName: Install Signing Plugin 1.1.1306
+                inputs:
+                  signType: real
+                  version: '1.1.1306'
+                  zipSources: false
+                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
+                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                env:
+                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -28,11 +28,7 @@ extends:
             templateContext:
               mb:
                 signing:
-                  enabled: true
-                  signType: real
-                  signWithProd: true
-                  zipSources: false
-                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                  enabled: false
               outputs:
                 - output: pipelineArtifact
                   artifactName: extension
@@ -42,6 +38,19 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: true
+              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate MicroBuild feed
+              - task: MicroBuildSigningPlugin@4
+                displayName: Install Signing Plugin 1.1.1306
+                inputs:
+                  signType: real
+                  version: '1.1.1306'
+                  zipSources: false
+                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
+                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                env:
+                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:


### PR DESCRIPTION
## Summary
- disable the template-managed signing plugin installation for Windows nightly and RC builds
- explicitly install `MicroBuild.Plugins.Signing` `1.1.1306` using the same MSEng feed and PME service connection
- keep the existing JAR and VSIX signing steps unchanged

## Context
`1.1.1374` fails on the Windows signing path with `Unable to find certificate ea4022a2-6f71-4214-88b6-18d2bbd6b4cc`. Build [31695746](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31695746) successfully signed the same artifacts with `1.1.1306`.

This is a temporary pin until the MicroBuild Windows client-certificate regression is resolved.

## Validation
- parsed both modified pipeline files with `js-yaml`
- ran `git diff --check`