### PR TITLE
fix: hide empty non-Java folder ancestors

### DIFF
--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
@@ -110,7 +110,9 @@ public class ResourceSet {
                     visitor.visit((IFile) resource);
                 }
             } else if (resource instanceof IFolder) {
-                if (shouldVisit((IFolder) resource) && hasVisibleNonJavaResources((IFolder) resource)) {
+                if (shouldVisit((IFolder) resource)
+                        && (!containsSourceClasspathEntry((IFolder) resource)
+                                || hasVisibleNonJavaResources((IFolder) resource))) {
                     visitor.visit((IFolder) resource);
                 }
             } else if (resource instanceof IJarEntryResource) {
@@ -152,6 +154,28 @@ public class ResourceSet {
         }
 
         return JavaCore.create(resource) == null;
+    }
+
+    private boolean containsSourceClasspathEntry(IContainer container) {
+        try {
+            IJavaProject javaProject = JavaCore.create(container.getProject());
+            if (javaProject == null) {
+                return false;
+            }
+            IPath containerPath = container.getFullPath();
+            if (containerPath.equals(javaProject.getOutputLocation())) {
+                return false;
+            }
+            for (IClasspathEntry entry : javaProject.getRawClasspath()) {
+                if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE
+                        && containerPath.isPrefixOf(entry.getPath())) {
+                    return true;
+                }
+            }
+        } catch (CoreException e) {
+            JdtlsExtActivator.logException("Failed to inspect Java source entries", e);
+        }
+        return false;
     }
 
     private boolean hasVisibleNonJavaResources(IContainer container) {

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
@@ -187,8 +187,11 @@ public class ResourceSet {
                 if (member instanceof IFile) {
                     return true;
                 }
-                if (member instanceof IContainer && hasVisibleNonJavaResources((IContainer) member)) {
-                    return true;
+                if (member instanceof IContainer) {
+                    IContainer child = (IContainer) member;
+                    if (!containsSourceClasspathEntry(child) || hasVisibleNonJavaResources(child)) {
+                        return true;
+                    }
                 }
             }
         } catch (CoreException e) {

--- a/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
+++ b/jdtls.ext/com.microsoft.jdtls.ext.core/src/com/microsoft/jdtls/ext/core/parser/ResourceSet.java
@@ -16,6 +16,7 @@ import java.util.ListIterator;
 import java.util.Objects;
 
 import org.eclipse.core.internal.utils.FileUtil;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -109,7 +110,7 @@ public class ResourceSet {
                     visitor.visit((IFile) resource);
                 }
             } else if (resource instanceof IFolder) {
-                if (shouldVisit((IFolder) resource)) {
+                if (shouldVisit((IFolder) resource) && hasVisibleNonJavaResources((IFolder) resource)) {
                     visitor.visit((IFolder) resource);
                 }
             } else if (resource instanceof IJarEntryResource) {
@@ -151,5 +152,25 @@ public class ResourceSet {
         }
 
         return JavaCore.create(resource) == null;
+    }
+
+    private boolean hasVisibleNonJavaResources(IContainer container) {
+        try {
+            for (IResource member : container.members()) {
+                if (JavaCore.create(member) != null) {
+                    continue;
+                }
+                if (member instanceof IFile) {
+                    return true;
+                }
+                if (member instanceof IContainer && hasVisibleNonJavaResources((IContainer) member)) {
+                    return true;
+                }
+            }
+        } catch (CoreException e) {
+            JdtlsExtActivator.logException("Failed to inspect non-Java resources", e);
+            return true;
+        }
+        return false;
     }
 }

--- a/test/e2e-plans/java-dep-view-modes.yaml
+++ b/test/e2e-plans/java-dep-view-modes.yaml
@@ -222,3 +222,44 @@ steps:
       exact: true
       inView: "Java Projects"
     timeout: 30
+
+  # ── Test 6: do not show empty physical ancestors of package roots (#1062) ──
+  # src/main/java and src/main/resources are represented as Java package roots.
+  # The physical src → main hierarchy must not also appear as an empty normal
+  # folder tree when non-Java resources are shown.
+  - id: "reset-tree-for-non-java-ancestor-check"
+    action: "executeVSCodeCommand workbench.actions.treeView.javaProjectExplorer.collapseAll"
+
+  - id: "expand-project-for-non-java-ancestor-check"
+    action: "expandTreeItem my-app"
+    waitBefore: 2
+
+  - id: "verify-resources-root-visible"
+    action: "wait 1 seconds"
+    verifyTreeItem:
+      name: "src/main/resources"
+      exact: true
+      level: 2
+      inView: "Java Projects"
+    timeout: 15
+
+  - id: "expand-resources-root"
+    action: "expandTreeItem src/main/resources"
+
+  - id: "verify-resource-file-visible"
+    action: "wait 1 seconds"
+    verifyTreeItem:
+      name: "application.yml"
+      exact: true
+      inView: "Java Projects"
+    timeout: 15
+
+  - id: "verify-empty-physical-src-hidden"
+    action: "wait 1 seconds"
+    verifyTreeItem:
+      name: "src"
+      exact: true
+      level: 2
+      visible: false
+      inView: "Java Projects"
+    timeout: 15

--- a/test/maven-suite/projectView.test.ts
+++ b/test/maven-suite/projectView.test.ts
@@ -3,7 +3,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { Commands, ContainerNode, contextManager, DataNode, DependencyExplorer, FileNode,
+import { Commands, ContainerNode, contextManager, DataNode, DependencyExplorer, FileNode, FolderNode,
     INodeData, Jdtls, languageServerApiManager, NodeKind, PackageNode, PackageRootNode, PrimaryTypeNode, ProjectNode } from "../../extension.bundle";
 import { fsPath, printNodes, setupTestEnv, Uris } from "../shared";
 
@@ -261,6 +261,45 @@ suite("Maven Project View Tests", () => {
         const resourceChildren = await resourcesRoot.getChildren();
         assert.ok(resourceChildren.find((node: DataNode) => node.nodeData.name === "application.yml"),
             "Non-Java files under the resources root should remain visible");
+    });
+
+    test("Displays empty non-Java folders next to Java package roots", async function() {
+        const explorer = DependencyExplorer.getInstance(contextManager.context);
+        const projectNode = (await explorer.dataProvider.getChildren())![0] as ProjectNode;
+        const initialChildren = await projectNode.getChildren();
+        const mainSourceRoot = initialChildren.find((node: DataNode) =>
+            node.nodeData.name === "src/main/java") as PackageRootNode;
+        const srcPath = mainSourceRoot.nodeData.path!.replace(/\/main\/java$/, "");
+        const docsUri = vscode.Uri.joinPath(vscode.Uri.file(Uris.MAVEN_PROJECT_NODE), "src", "docs");
+        await vscode.workspace.fs.createDirectory(docsUri);
+
+        try {
+            await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND,
+                Commands.JAVA_GETPACKAGEDATA, {
+                    kind: NodeKind.Folder,
+                    projectUri: projectNode.uri,
+                    path: srcPath,
+                });
+            await vscode.commands.executeCommand(Commands.VIEW_PACKAGE_REFRESH);
+            const refreshedProjectNode = (await explorer.dataProvider.getChildren())![0] as ProjectNode;
+            const projectChildren = await refreshedProjectNode.getChildren();
+            const srcFolder = projectChildren.find((node: DataNode) =>
+                node.nodeData.name === "src") as FolderNode;
+
+            assert.ok(srcFolder, "The physical src folder should remain visible when it contains an empty non-Java folder");
+            const srcChildren = await srcFolder.getChildren();
+            assert.ok(srcChildren.find((node: DataNode) => node.nodeData.name === "docs"),
+                "The empty non-Java folder should remain visible");
+        } finally {
+            await vscode.workspace.fs.delete(docsUri, { recursive: true });
+            await vscode.commands.executeCommand(Commands.EXECUTE_WORKSPACE_COMMAND,
+                Commands.JAVA_GETPACKAGEDATA, {
+                    kind: NodeKind.Folder,
+                    projectUri: projectNode.uri,
+                    path: srcPath,
+                });
+            await vscode.commands.executeCommand(Commands.VIEW_PACKAGE_REFRESH);
+        }
     });
 
     test("Can apply 'java.project.explorer.showNonJavaResources'", async function() {

--- a/test/maven-suite/projectView.test.ts
+++ b/test/maven-suite/projectView.test.ts
@@ -247,6 +247,22 @@ suite("Maven Project View Tests", () => {
         assert.ok(!projectChildren.find((node: DataNode) => node.nodeData.name === ".hidden"));
     });
 
+    test("Does not display empty physical ancestors of Java package roots", async function() {
+        const explorer = DependencyExplorer.getInstance(contextManager.context);
+        const projectNode = (await explorer.dataProvider.getChildren())![0] as ProjectNode;
+        const projectChildren = await projectNode.getChildren();
+
+        assert.ok(!projectChildren.find((node: DataNode) => node.nodeData.name === "src"),
+            "The physical src folder should not duplicate Java package roots");
+
+        const resourcesRoot = projectChildren.find((node: DataNode) =>
+            node.nodeData.name === "src/main/resources") as PackageRootNode;
+        assert.ok(resourcesRoot, "The Maven resources root should remain visible");
+        const resourceChildren = await resourcesRoot.getChildren();
+        assert.ok(resourceChildren.find((node: DataNode) => node.nodeData.name === "application.yml"),
+            "Non-Java files under the resources root should remain visible");
+    });
+
     test("Can apply 'java.project.explorer.showNonJavaResources'", async function() {
         await vscode.workspace.getConfiguration("java.project.explorer").update(
             "showNonJavaResources",

--- a/test/maven/src/main/resources/application.yml
+++ b/test/maven/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: my-app

--- a/test/simple-suite/projectView.test.ts
+++ b/test/simple-suite/projectView.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { ContainerNode, contextManager, DependencyExplorer,
+import { ContainerNode, contextManager, DataNode, DependencyExplorer,
     PackageRootNode, PrimaryTypeNode, ProjectNode } from "../../extension.bundle";
 import { fsPath, setupTestEnv, Uris } from "../shared";
 
@@ -22,7 +22,10 @@ suite("Simple Project View Tests", () => {
 
         // validate package root/dependency nodes
         const projectChildren = await projectNode.getChildren();
-        assert.equal(projectChildren.length, 6, "Number of children nodes should be 6");
+        assert.equal(projectChildren.length, 5,
+            `Number of children nodes should be 5: ${projectChildren.map((node: DataNode) => node.name).join(", ")}`);
+        assert.ok(!projectChildren.find((node: DataNode) => node.name === "src"),
+            "The empty physical source folder should not be visible");
         const mainPackage = projectChildren[0] as PackageRootNode;
         assert.equal(mainPackage.name, "src/main/java", "Package name should be \"src/main/java\"");
         const systemLibrary = projectChildren[1] as ContainerNode;


### PR DESCRIPTION
## Summary

- hide physical non-Java folder ancestors when their entire subtree is already represented by Java model/package-root nodes
- keep real non-Java resources visible through their Java resource root
- add a Maven regression fixture and project-view test for the empty `src/main` hierarchy

This fixes the empty physical `src/main` tree reported when **Show Non-Java Resources** is enabled. It intentionally does not change the visibility policy for Maven `target` or other build-output folders.

## Root cause

`java.getPackageData` combines Java classpath roots with `IJavaProject.getNonJavaResources()`. A physical ancestor such as `src` could therefore be emitted as a normal folder even though `src/main/java` and `src/main/resources` were already represented as package roots. Expanding the physical folder filtered those Java elements and left an empty hierarchy.

## Testing

- JDTLS extension build and checkstyle
- `npm run compile`
- `npm run tslint`
- Maven Project View Tests: 15 passing
- AutoTest `java-dep-view-modes`: 36/36 passing with the fix
- Pre-fix A/B: 35/36 passing; only `verify-empty-physical-src-hidden` fails

Fixes #1062
Related to #1044

## UI verification

The Maven resource root and `application.yml` remain visible, while the duplicate physical `src` hierarchy is absent.

| Before | After |
| --- | --- |
| The extra physical `src` folder is shown below `.vscode`. | The extra `src` folder is removed; `target` follows `.vscode`. |
| ![Before: duplicate physical src folder](https://github.com/user-attachments/assets/347e553a-0139-490c-90d0-15468c30be85) | ![After: duplicate physical src folder removed](https://github.com/user-attachments/assets/9efe5b6f-99a0-47ed-977b-ce6ee3ebfa8d) |

![UI verification for empty src hierarchy fix](https://github.com/user-attachments/assets/261b0010-6f49-49fd-a7ef-2fe556927cc9)


