### PR TITLE
fix: show non-Java resource toggle in view toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,12 +253,14 @@
       {
         "command": "java.project.explorer.showNonJavaResources",
         "title": "%contributes.commands.java.project.explorer.showNonJavaResources%",
-        "category": "Java"
+        "category": "Java",
+        "icon": "$(eye)"
       },
       {
         "command": "java.project.explorer.hideNonJavaResources",
         "title": "%contributes.commands.java.project.explorer.hideNonJavaResources%",
-        "category": "Java"
+        "category": "Java",
+        "icon": "$(eye-closed)"
       },
       {
         "command": "java.view.package.revealFileInOS",
@@ -754,12 +756,12 @@
         {
           "command": "java.project.explorer.showNonJavaResources",
           "when": "view == javaProjectExplorer && java:serverMode == Standard && !config.java.project.explorer.showNonJavaResources",
-          "group": "overflow_10@30"
+          "group": "navigation@40"
         },
         {
           "command": "java.project.explorer.hideNonJavaResources",
           "when": "view == javaProjectExplorer && java:serverMode == Standard && config.java.project.explorer.showNonJavaResources",
-          "group": "overflow_10@30"
+          "group": "navigation@40"
         },
         {
           "command": "java.project.rebuild.workspace",

--- a/test/e2e-plans/java-dep-view-modes.yaml
+++ b/test/e2e-plans/java-dep-view-modes.yaml
@@ -182,11 +182,9 @@ steps:
 
   - id: "hide-non-java"
     action: 'clickViewTitleAction "Java Projects" "Hide Non-Java Resources"'
-    # Real UI path through view-title overflow menu. The menu item label
-    # toggles based on `config.java.project.explorer.showNonJavaResources`
-    # (Show vs Hide), and the current state at this point is "showing"
-    # so the menu surfaces "Hide Non-Java Resources". verifyTreeItem
-    # checks below are authoritative.
+    # Direct view-title toolbar action. Its label and icon toggle based on
+    # `config.java.project.explorer.showNonJavaResources`; the current state
+    # is "showing", so the toolbar surfaces "Hide Non-Java Resources".
 
   - id: "wait-hide"
     action: "wait 5 seconds"
@@ -203,9 +201,8 @@ steps:
   # ── Test 5: show non-Java resources ──
   - id: "show-non-java"
     action: 'clickViewTitleAction "Java Projects" "Show Non-Java Resources"'
-    # Real UI path through view-title overflow menu. After hide-non-java
-    # the toggle now surfaces "Show Non-Java Resources". verifyTreeItem
-    # below is authoritative.
+    # After hide-non-java, the same toolbar position surfaces
+    # "Show Non-Java Resources".
 
   - id: "wait-show"
     action: "wait 5 seconds"


### PR DESCRIPTION
## Summary

- Promote the Show/Hide Non-Java Resources action from the overflow menu to the Java Projects title toolbar.
- Use `eye` and `eye-closed` icons while preserving the existing mutually exclusive configuration conditions.
- Keep the existing Show/Hide behavior unchanged and update the AutoTest plan to exercise the toolbar action.

## Validation

- AutoTest plan validation: `java-dep-view-modes.yaml`
- JDT LS bundle build and VSIX packaging
- AutoTest 0.7.25 — View Modes & Refresh: 36/36 passing

## UI verification

### Resources shown: Hide action

![Hide Non-Java Resources in the Java Projects title toolbar](https://github.com/user-attachments/assets/30eefe02-b1cd-4737-9baa-67f420c1b4b8)

### Resources hidden: Show action

![Show Non-Java Resources in the Java Projects title toolbar](https://github.com/user-attachments/assets/13e91fff-7da1-4cbf-9eae-165c3b203771)

