### PR TITLE
chore(deps): update js-yaml to patched releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,9 +2181,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3651,10 +3651,11 @@
       }
     },
     "node_modules/tslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5662,9 +5663,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -6617,9 +6618,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+          "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",


### PR DESCRIPTION
## Summary

Fix all five currently open Dependabot alerts by updating only development-time `js-yaml` resolutions in `package-lock.json`:

- [Top-level js-yaml](https://github.com/microsoft/vscode-java-dependency/blob/5ec13009672c8994a7b0c3d4cf9b46866c964cf2/package-lock.json#L2183-L2207): `4.2.0` -> `4.3.2`, used by Mocha (`^4.1.0`) and webpack-cli's optional peer (`^4.0.0 || ^5.0.0`).
- [TSLint's nested js-yaml](https://github.com/microsoft/vscode-java-dependency/blob/5ec13009672c8994a7b0c3d4cf9b46866c964cf2/package-lock.json#L3653-L3666): `3.14.2` -> `3.15.2`, satisfying TSLint's `^3.13.1` constraint.

Generated with `npm update js-yaml --package-lock-only --ignore-scripts --no-fund`. Preserve lockfile version 2, both lockfile representations, all parent versions/constraints and every unrelated resolution. No manifest, runtime source, overrides, test or changelog changes.

## Alert coverage

| Alerts | Advisory | Safe floors | Locked versions |
| --- | --- | --- | --- |
| [111](https://github.com/microsoft/vscode-java-dependency/security/dependabot/111), [110](https://github.com/microsoft/vscode-java-dependency/security/dependabot/110) | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj): quadratic ordered-map resolution | 3.15.1 / 4.3.1 | 3.15.2 / 4.3.2 |
| [100](https://github.com/microsoft/vscode-java-dependency/security/dependabot/100), [101](https://github.com/microsoft/vscode-java-dependency/security/dependabot/101) | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m): quadratic merge-key chains | 3.15.0 / 4.3.0 | 3.15.2 / 4.3.2 |
| [96](https://github.com/microsoft/vscode-java-dependency/security/dependabot/96) | [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68): repeated merge-alias CPU exhaustion | 3.15.0 | 3.15.2 |

## Validation

- `npm ci --ignore-scripts --no-fund` passed.
- `npm run build-server && npm test && npm run tslint` passed on Windows with Node 22.15.1, npm 10.9.2 and JDK 21; all 61 tests passed. The Maven wrapper directory was added only to process-local PATH because this host sets `NoDefaultCurrentDirectoryInExePath=1`.
- Verified every locked js-yaml instance and legacy lock entry against all advisory ranges, all three parent constraints, and ordinary merge/ordered-map parsing. Exact graph comparison permits only 12 version/URL/integrity changes plus upstream MIT license metadata; no unrelated graph delta.
- `npm audit --package-lock-only --ignore-scripts --json` no longer reports js-yaml. The two unchanged low-severity `diff`/Mocha audit findings correspond to already auto-dismissed alerts [49](https://github.com/microsoft/vscode-java-dependency/security/dependabot/49) and [46](https://github.com/microsoft/vscode-java-dependency/security/dependabot/46), both [GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx). No broad audit fix or alert-state changes.

Local caveat: two earlier full runs failed the multi-module import-tree assertion after 54 passing tests. The final unchanged patched full run passed all 61, as did the exact original-lock full baseline; the isolated multi-module suite passed with both old and new versions. The intermittent failure's cause was not established. No assertions, timeouts or source were changed; generated fixture settings were restored.