### PR TITLE
build: validate dependency updates through CFS

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -28,6 +28,7 @@ pr:
       - scripts/buildJdtlsExt.js
       - jdtls.ext/pom.xml
       - jdtls.ext/**/pom.xml
+      - jdtls.ext/**/META-INF/MANIFEST.MF
       - jdtls.ext/com.microsoft.jdtls.ext.target/com.microsoft.jdtls.ext.tp.target
       - jdtls.ext/.mvn/wrapper/maven-wrapper.properties
       - jdtls.ext/mvnw

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -17,6 +17,26 @@ trigger:
   branches:
     include:
       - main
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - package.json
+      - package-lock.json
+      - scripts/buildJdtlsExt.js
+      - jdtls.ext/pom.xml
+      - jdtls.ext/**/pom.xml
+      - jdtls.ext/com.microsoft.jdtls.ext.target/com.microsoft.jdtls.ext.tp.target
+      - jdtls.ext/.mvn/wrapper/maven-wrapper.properties
+      - jdtls.ext/mvnw
+      - jdtls.ext/mvnw.cmd
+      - .azure-pipelines/ci.yml
+      - .azure-pipelines/npm-cfs.yml
+      - .azure-pipelines/npm-cfs-variables.yml
+      - .azure-pipelines/maven-cfs-variables.yml
+      - .azure-pipelines/cfs-settings.xml
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -34,8 +54,35 @@ extends:
     stages:
       - stage: Build
         jobs:
+          - job: CFSValidation
+            displayName: Validate dependencies from CFS
+            condition: eq(variables['Build.Reason'], 'PullRequest')
+            steps:
+              - checkout: self
+                fetchTags: false
+              - task: JavaToolInstaller@0
+                displayName: Use Java 21
+                inputs:
+                  versionSpec: "21"
+                  jdkArchitectureOption: x64
+                  jdkSourceOption: PreInstalled
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
+              - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
+                displayName: Validate npm dependencies from CFS
+              - script: npm run build-server
+                displayName: Validate Maven dependencies from CFS
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
+                  MAVEN_USER_HOME: $(Agent.TempDirectory)/m2
+                  MAVEN_ARGS: -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml -Dmaven.repo.local=$(Agent.TempDirectory)/m2/repository -U
           - job: Job_1
             displayName: CI
+            condition: ne(variables['Build.Reason'], 'PullRequest')
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -72,15 +72,13 @@ extends:
                 inputs:
                   versionSpec: 20.x
               - template: /.azure-pipelines/npm-cfs.yml@self
-                parameters:
-                  useReadOnlyCredential: true
               - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
                 displayName: Validate npm dependencies from CFS
               - script: npm run build-server
                 displayName: Validate Maven dependencies from CFS
                 env:
-                  SYSTEM_ACCESSTOKEN: $(CFS_READ_TOKEN)
-                  MVNW_PASSWORD: $(CFS_READ_TOKEN)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                   MAVEN_USER_HOME: $(Agent.TempDirectory)/m2
                   MAVEN_ARGS: -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml -Dmaven.repo.local=$(Agent.TempDirectory)/m2/repository -U
           - job: Job_1

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -72,13 +72,15 @@ extends:
                 inputs:
                   versionSpec: 20.x
               - template: /.azure-pipelines/npm-cfs.yml@self
+                parameters:
+                  useReadOnlyCredential: true
               - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
                 displayName: Validate npm dependencies from CFS
               - script: npm run build-server
                 displayName: Validate Maven dependencies from CFS
                 env:
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-                  MVNW_PASSWORD: $(System.AccessToken)
+                  SYSTEM_ACCESSTOKEN: $(CFS_READ_TOKEN)
+                  MVNW_PASSWORD: $(CFS_READ_TOKEN)
                   MAVEN_USER_HOME: $(Agent.TempDirectory)/m2
                   MAVEN_ARGS: -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml -Dmaven.repo.local=$(Agent.TempDirectory)/m2/repository -U
           - job: Job_1

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -63,6 +63,8 @@ steps:
           node -e "const fs=require('fs');const r=new URL(process.env.npm_config_registry);const key='//'+r.host+r.pathname.replace(/\/?$/,'/');fs.appendFileSync(process.env.npm_config_userconfig,key+':_authToken='+process.env.CFS_READ_TOKEN+'\n');"
         displayName: Authenticate to CFS feed with read-only credential
         env:
+          npm_config_registry: $(npm_config_registry)
+          npm_config_userconfig: $(npm_config_userconfig)
           CFS_READ_TOKEN: $(CFS_READ_TOKEN)
 
   # Restore silently falling back to the public registry is the failure mode this

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -36,6 +36,11 @@
 # pipelines is the 1ES extends template in another repository, so the unqualified
 # form is looked up in 1ESPipelineTemplates and fails YAML compilation.
 
+parameters:
+  - name: useReadOnlyCredential
+    type: boolean
+    default: false
+
 steps:
   - script: npm config set registry $(npm_config_registry) --location=user --userconfig="$(npm_config_userconfig)"
     displayName: Configure CFS npm registry
@@ -44,10 +49,21 @@ steps:
   # registry it finds in the file above. `always-auth` is deliberately not written:
   # it is not read by this task and is rejected outright by the npm 10 shipped with
   # Node 20.
-  - task: NpmAuthenticate@0
-    displayName: Authenticate to CFS feed
-    inputs:
-      workingFile: $(npm_config_userconfig)
+  - ${{ if not(parameters.useReadOnlyCredential) }}:
+      - task: NpmAuthenticate@0
+        displayName: Authenticate to CFS feed
+        inputs:
+          workingFile: $(npm_config_userconfig)
+
+  # PR validation runs repository-controlled code, so it must not receive the
+  # project-scoped System.AccessToken used by trusted branch builds. Its pipeline
+  # definition supplies a secret PAT restricted to Packaging Read.
+  - ${{ if parameters.useReadOnlyCredential }}:
+      - script: >-
+          node -e "const fs=require('fs');const r=new URL(process.env.npm_config_registry);const key='//'+r.host+r.pathname.replace(/\/?$/,'/');fs.appendFileSync(process.env.npm_config_userconfig,key+':_authToken='+process.env.CFS_READ_TOKEN+'\n');"
+        displayName: Authenticate to CFS feed with read-only credential
+        env:
+          CFS_READ_TOKEN: $(CFS_READ_TOKEN)
 
   # Restore silently falling back to the public registry is the failure mode this
   # whole template exists to prevent, and it leaves no trace in the build log, so it

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -36,11 +36,6 @@
 # pipelines is the 1ES extends template in another repository, so the unqualified
 # form is looked up in 1ESPipelineTemplates and fails YAML compilation.
 
-parameters:
-  - name: useReadOnlyCredential
-    type: boolean
-    default: false
-
 steps:
   - script: npm config set registry $(npm_config_registry) --location=user --userconfig="$(npm_config_userconfig)"
     displayName: Configure CFS npm registry
@@ -49,23 +44,10 @@ steps:
   # registry it finds in the file above. `always-auth` is deliberately not written:
   # it is not read by this task and is rejected outright by the npm 10 shipped with
   # Node 20.
-  - ${{ if not(parameters.useReadOnlyCredential) }}:
-      - task: NpmAuthenticate@0
-        displayName: Authenticate to CFS feed
-        inputs:
-          workingFile: $(npm_config_userconfig)
-
-  # PR validation runs repository-controlled code, so it must not receive the
-  # project-scoped System.AccessToken used by trusted branch builds. Its pipeline
-  # definition supplies a secret PAT restricted to Packaging Read.
-  - ${{ if parameters.useReadOnlyCredential }}:
-      - script: >-
-          node -e "const fs=require('fs');const r=new URL(process.env.npm_config_registry);const key='//'+r.host+r.pathname.replace(/\/?$/,'/');fs.appendFileSync(process.env.npm_config_userconfig,key+':_authToken='+process.env.CFS_READ_TOKEN+'\n');"
-        displayName: Authenticate to CFS feed with read-only credential
-        env:
-          npm_config_registry: $(npm_config_registry)
-          npm_config_userconfig: $(npm_config_userconfig)
-          CFS_READ_TOKEN: $(CFS_READ_TOKEN)
+  - task: NpmAuthenticate@0
+    displayName: Authenticate to CFS feed
+    inputs:
+      workingFile: $(npm_config_userconfig)
 
   # Restore silently falling back to the public registry is the failure mode this
   # whole template exists to prevent, and it leaves no trace in the build log, so it

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    # CI restores packages from the Central Feed Service, which withholds
-    # upstream versions until they are roughly a week old (measured at ~6.8
-    # days; both the packument entry and the tarball return 404 before then).
-    # Dependabot's built-in cooldown is only 3 days, so bumps otherwise land in
-    # a window where the feed 404s and the build fails. 10 days leaves margin
-    # in case the feed's ingestion lag drifts.
-    cooldown:
-      default-days: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:


### PR DESCRIPTION
## Summary

- add an Azure DevOps PR validation job for Component Framework Service (CFS)
- validate npm and Maven/Tycho dependency updates with isolated caches
- run CFS validation only when dependency inputs or CFS configuration change
- remove scheduled npm Dependabot updates now covered by CFS

## Validation

- parsed `.azure-pipelines/ci.yml` with `js-yaml`
- parsed `cfs-settings.xml`
- validated the expanded Azure DevOps pipeline preview
- ran `git diff --check`

`npm run compile` currently reports the existing `minimatch`/`glob` type incompatibility also present outside this YAML-only change.